### PR TITLE
Integrate faultline gem for exception tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem "jbuilder"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
+# Exception and error tracking [https://github.com/dlt/faultline]
+gem "faultline", git: "https://github.com/dlt/faultline.git"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/dlt/faultline.git
+  revision: bf52ad4b7cba6ba059d7cb54e4131060a31c6831
+  specs:
+    faultline (0.1.0)
+      rails (>= 8.0)
+
+GIT
   remote: https://github.com/eirvandelden/mvpa.css.git
   revision: 534bcaab37e1f1be7a98ec862a283a69a6b4cb46
   specs:
@@ -380,6 +387,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  faultline!
   importmap-rails
   jbuilder
   kamal

--- a/config/initializers/faultline.rb
+++ b/config/initializers/faultline.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+Faultline.configure do |config|
+  # =============================================================================
+  # User Configuration
+  # =============================================================================
+
+  # User class for association (default: "User")
+  config.user_class = "User"
+
+  # Method to get current user in controllers
+  config.user_method = :current_user
+
+  # Custom context - add extra data to every error occurrence
+  # Receives request and Rack env, should return a hash
+  # config.custom_context = lambda { |request, env|
+  #   controller = env["action_controller.instance"]
+  #   {
+  #     account_id: controller&.current_account&.id,
+  #     tenant: request.subdomain
+  #   }
+  # }
+
+  # =============================================================================
+  # Error Filtering
+  # =============================================================================
+
+  # Exceptions to ignore (won't be tracked)
+  config.ignored_exceptions = [
+    "ActiveRecord::RecordNotFound",
+    "ActionController::RoutingError",
+    "ActionController::UnknownFormat"
+  ]
+
+  # User agents to ignore (bots, crawlers)
+  config.ignored_user_agents = [
+    /bot/i, /crawler/i, /spider/i, /Googlebot/i, /Bingbot/i, /Slurp/i
+  ]
+
+  # =============================================================================
+  # Dashboard Authentication
+  # =============================================================================
+
+  # Return true if the user should have access to the dashboard
+  # IMPORTANT: Configure this before deploying to production!
+  # Restrict dashboard to admin users using the app's existing role system.
+  # The app uses signed cookie-based sessions; we read the session token from
+  # the cookie to look up the current user without relying on warden/devise.
+  config.authenticate_with = lambda { |request|
+    token = request.cookie_jar.signed[:session_token]
+    session = Session.find_by(token: token)
+    session&.user&.admin?
+  }
+
+  # Optional: Additional authorization after authentication
+  # config.authorize_with = lambda { |request|
+  #   # Add extra authorization logic here
+  #   true
+  # }
+
+  # =============================================================================
+  # Notifications
+  # =============================================================================
+
+  # App name for notifications (shown in alert messages)
+  config.app_name = Rails.application.class.module_parent_name
+
+  # Notification rules - when to send alerts
+  config.notification_rules = {
+    on_first_occurrence: true,           # Alert on new error types
+    on_reopen: true,                     # Alert when resolved errors reoccur
+    on_threshold: [ 10, 50, 100, 500 ],    # Alert at these occurrence counts
+    critical_exceptions: [],              # Always alert for these exception classes
+    notify_in_environments: [ "production" ]
+  }
+
+  # --- Telegram Notifier ---
+  # Store credentials in Rails credentials:
+  #   rails credentials:edit
+  #   telegram:
+  #     bot_token: "your-bot-token"
+  #     chat_id: "your-chat-id"
+  #
+  # if Rails.application.credentials.dig(:faultline, :telegram, :bot_token)
+  #   config.add_notifier(
+  #     Faultline::Notifiers::Telegram.new(
+  #       bot_token: Rails.application.credentials.dig(:faultline, :telegram, :bot_token),
+  #       chat_id: Rails.application.credentials.dig(:faultline, :telegram, :chat_id)
+  #     )
+  #   )
+  # end
+
+  # --- Slack Notifier ---
+  # Store webhook URL in Rails credentials:
+  #   rails credentials:edit
+  #   faultline:
+  #     slack:
+  #       webhook_url: "https://hooks.slack.com/services/..."
+  #
+  # if Rails.application.credentials.dig(:faultline, :slack, :webhook_url)
+  #   config.add_notifier(
+  #     Faultline::Notifiers::Slack.new(
+  #       webhook_url: Rails.application.credentials.dig(:faultline, :slack, :webhook_url),
+  #       channel: "#errors",
+  #       username: "Faultline"
+  #     )
+  #   )
+  # end
+
+  # --- Generic Webhook Notifier ---
+  # For custom integrations (PagerDuty, Opsgenie, Discord, etc.)
+  #
+  # config.add_notifier(
+  #   Faultline::Notifiers::Webhook.new(
+  #     url: ENV["FAULTLINE_WEBHOOK_URL"],
+  #     method: :post,
+  #     headers: { "Authorization" => "Bearer #{ENV['FAULTLINE_WEBHOOK_TOKEN']}" }
+  #   )
+  # )
+
+  # --- Resend Email Notifier ---
+  # Sends error notifications via Resend API (https://resend.com)
+  # Store API key in Rails credentials:
+  #   rails credentials:edit
+  #   faultline:
+  #     resend:
+  #       api_key: "re_xxxxx"
+  #
+  # if Rails.application.credentials.dig(:faultline, :resend, :api_key)
+  #   config.add_notifier(
+  #     Faultline::Notifiers::Resend.new(
+  #       api_key: Rails.application.credentials.dig(:faultline, :resend, :api_key),
+  #       from: "errors@yourdomain.com",
+  #       to: "team@example.com"            # or array: ["dev@example.com", "ops@example.com"]
+  #     )
+  #   )
+  # end
+
+  # --- Email Notifier (ActionMailer) ---
+  # Sends error notifications using your app's existing mail configuration.
+  # Uses ActionMailer with deliver_later (requires Active Job).
+  #
+  # config.add_notifier(
+  #   Faultline::Notifiers::Email.new(
+  #     to: ["team@example.com", "oncall@example.com"],
+  #     from: "errors@yourdomain.com"  # optional, defaults to ActionMailer default
+  #   )
+  # )
+
+  # Notification cooldown - prevent spam during error storms (nil to disable)
+  config.notification_cooldown = 5.minutes
+
+  # =============================================================================
+  # GitHub Integration
+  # =============================================================================
+
+  # Create GitHub issues from error groups with full context.
+  # Store credentials in Rails credentials:
+  #   rails credentials:edit
+  #   faultline:
+  #     github:
+  #       token: "ghp_xxxxx"
+  #
+  # config.github_repo = "your-org/your-repo"
+  # config.github_token = Rails.application.credentials.dig(:faultline, :github, :token)
+
+  # Labels to add to created issues (customize for your workflow)
+  # Add "faultline-auto-fix" to trigger AI auto-fix via GitHub Actions
+  # config.github_labels = ["bug", "faultline", "faultline-auto-fix"]
+
+  # =============================================================================
+  # Error Capture Configuration
+  # =============================================================================
+
+  # Enable Rack middleware to catch unhandled exceptions automatically
+  config.enable_middleware = true
+
+  # Subscribe to Rails error reporting API (Rails.error.report/handle/record)
+  # This captures errors from background jobs and explicit Rails.error calls
+  # config.register_error_subscriber = true
+
+  # Paths to ignore (no error tracking for these)
+  config.middleware_ignore_paths = [ "/assets", "/up" ]
+
+  # =============================================================================
+  # Data Configuration
+  # =============================================================================
+
+  # Maximum backtrace lines to store per occurrence
+  config.backtrace_lines_limit = 50
+
+  # How long to keep error data in days (nil = forever)
+  # Consider setting up a cleanup job if you have high error volume
+  config.retention_days = 90
+
+  # =============================================================================
+  # Callbacks (Advanced)
+  # =============================================================================
+
+  # Before tracking - return false to skip tracking this error
+  # config.before_track = lambda { |exception, context|
+  #   # Example: Skip timeout errors
+  #   return false if exception.message.include?("Timeout")
+  #   true
+  # }
+
+  # After tracking - for custom integrations
+  # config.after_track = lambda { |error_group, occurrence|
+  #   # Example: Send to analytics
+  #   Analytics.track("error_occurred", {
+  #     exception: error_group.exception_class,
+  #     count: error_group.occurrences_count
+  #   })
+  # }
+
+  # Custom fingerprinting - control how errors are grouped
+  # config.custom_fingerprint = lambda { |exception, context|
+  #   # Example: Group by feature flag
+  #   { extra_components: [context.dig(:custom_data, :feature_flag)] }
+  # }
+
+  # =============================================================================
+  # Application Performance Monitoring (APM)
+  # =============================================================================
+
+  # Enable basic APM to track request performance metrics.
+  # Captures response times, database queries, and throughput per endpoint.
+  # config.enable_apm = true
+
+  # Sample rate for high-traffic apps (0.0 to 1.0, default: 1.0 = every request)
+  # config.apm_sample_rate = 1.0
+
+  # Paths to ignore for APM (defaults to middleware_ignore_paths if nil)
+  # config.apm_ignore_paths = ["/assets", "/up", "/health", "/faultline"]
+
+  # How long to keep APM traces in days (default: 30)
+  # Use `rake faultline:apm:cleanup` to remove old traces.
+  # config.apm_retention_days = 30
+
+  # --- Span Collection (Waterfall Visualization) ---
+  # Capture detailed spans for SQL, HTTP, Redis, and view rendering.
+  # When enabled, traces include a waterfall timeline showing each operation.
+  # config.apm_capture_spans = true  # default: true when APM enabled
+
+  # --- CPU Profiling (Flame Graphs) ---
+  # Enable sampling-based profiling using stackprof for flame graph visualization.
+  # Requires: gem 'stackprof' in your Gemfile
+  # config.apm_enable_profiling = false  # disabled by default
+
+  # Profile only a sample of requests to minimize overhead (0.0 to 1.0)
+  # config.apm_profile_sample_rate = 0.1  # 10% of requests
+
+  # Profiler sampling interval in microseconds (default: 1000 = 1ms)
+  # Lower values = more detailed profiles but higher overhead
+  # config.apm_profile_interval = 1000
+
+  # Profile mode: :cpu (CPU time), :wall (wall clock), or :object (allocations)
+  # config.apm_profile_mode = :cpu
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Faultline::Engine, at: "/faultline"
   get "up" => "rails/health#show", as: :rails_health_check
 
   root "sessions#new"

--- a/db/migrate/20260219095208_create_faultline_error_groups.rb
+++ b/db/migrate/20260219095208_create_faultline_error_groups.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class CreateFaultlineErrorGroups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :faultline_error_groups do |t|
+      t.string :fingerprint, null: false
+      t.string :exception_class, null: false
+      t.text :sanitized_message, null: false
+      t.string :file_path
+      t.integer :line_number
+      t.string :method_name
+
+      t.integer :occurrences_count, default: 0
+      t.datetime :first_seen_at
+      t.datetime :last_seen_at
+      t.string :status, default: "unresolved"
+      t.datetime :resolved_at
+      t.datetime :last_notified_at
+
+      t.timestamps
+    end
+
+    add_index :faultline_error_groups, :fingerprint, unique: true
+    add_index :faultline_error_groups, :exception_class
+    add_index :faultline_error_groups, :status
+    add_index :faultline_error_groups, :last_seen_at
+
+    # PostgreSQL: Add full-text search column with GIN index
+    if postgresql?
+      execute <<-SQL
+        ALTER TABLE faultline_error_groups
+        ADD COLUMN searchable tsvector
+        GENERATED ALWAYS AS (
+          to_tsvector('simple',
+            coalesce(exception_class, '') || ' ' ||
+            coalesce(sanitized_message, '') || ' ' ||
+            coalesce(file_path, '')
+          )
+        ) STORED;
+      SQL
+
+      add_index :faultline_error_groups, :searchable, using: :gin
+    end
+  end
+
+  private
+
+  def postgresql?
+    ActiveRecord::Base.connection.adapter_name.downcase.include?("postgresql")
+  end
+end

--- a/db/migrate/20260219095209_create_faultline_error_occurrences.rb
+++ b/db/migrate/20260219095209_create_faultline_error_occurrences.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class CreateFaultlineErrorOccurrences < ActiveRecord::Migration[8.0]
+  def change
+    create_table :faultline_error_occurrences do |t|
+      t.references :error_group, null: false, foreign_key: { to_table: :faultline_error_groups }
+
+      t.string :exception_class, null: false
+      t.text :message, null: false
+      t.text :backtrace
+
+      t.string :request_method
+      t.string :request_url
+      t.text :request_params
+      t.text :request_headers
+      t.string :user_agent
+      t.string :ip_address
+
+      t.bigint :user_id
+      t.string :user_type
+      t.string :session_id
+
+      t.string :environment
+      t.string :hostname
+      t.string :process_id
+
+      t.json :local_variables
+
+      t.timestamps
+    end
+
+    add_index :faultline_error_occurrences, :created_at
+    add_index :faultline_error_occurrences, [ :error_group_id, :created_at ]
+    add_index :faultline_error_occurrences, [ :user_type, :user_id ]
+  end
+end

--- a/db/migrate/20260219095210_create_faultline_error_contexts.rb
+++ b/db/migrate/20260219095210_create_faultline_error_contexts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateFaultlineErrorContexts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :faultline_error_contexts do |t|
+      t.references :error_occurrence, null: false, foreign_key: { to_table: :faultline_error_occurrences }
+      t.string :key, null: false
+      t.text :value
+
+      t.timestamps
+    end
+
+    add_index :faultline_error_contexts, [ :error_occurrence_id, :key ]
+  end
+end

--- a/db/migrate/20260219095211_create_faultline_request_traces.rb
+++ b/db/migrate/20260219095211_create_faultline_request_traces.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateFaultlineRequestTraces < ActiveRecord::Migration[8.0]
+  def change
+    create_table :faultline_request_traces do |t|
+      t.string  :endpoint,        null: false
+      t.string  :http_method,     null: false
+      t.string  :path
+      t.integer :status
+      t.float   :duration_ms
+      t.float   :db_runtime_ms
+      t.float   :view_runtime_ms
+      t.integer :db_query_count,  default: 0
+
+      t.datetime :created_at,     null: false
+    end
+
+    add_index :faultline_request_traces, :endpoint
+    add_index :faultline_request_traces, :created_at
+    add_index :faultline_request_traces, [ :endpoint, :created_at ]
+  end
+end

--- a/db/migrate/20260219095212_add_spans_to_faultline_request_traces.rb
+++ b/db/migrate/20260219095212_add_spans_to_faultline_request_traces.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSpansToFaultlineRequestTraces < ActiveRecord::Migration[8.0]
+  def change
+    add_column :faultline_request_traces, :spans, :json
+    add_column :faultline_request_traces, :has_profile, :boolean, default: false
+  end
+end

--- a/db/migrate/20260219095213_create_faultline_request_profiles.rb
+++ b/db/migrate/20260219095213_create_faultline_request_profiles.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateFaultlineRequestProfiles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :faultline_request_profiles do |t|
+      t.references :request_trace, null: false, foreign_key: { to_table: :faultline_request_traces, on_delete: :cascade }
+      t.text :profile_data, null: false
+      t.string :mode, default: 'cpu'
+      t.integer :samples, default: 0
+      t.float :interval_ms
+
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/migrate/20260219095214_change_sanitized_message_to_text.rb
+++ b/db/migrate/20260219095214_change_sanitized_message_to_text.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeSanitizedMessageToText < ActiveRecord::Migration[8.0]
+  def up
+    change_column :faultline_error_groups, :sanitized_message, :text, null: false
+  end
+
+  def down
+    change_column :faultline_error_groups, :sanitized_message, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,97 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_12_120002) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_19_095214) do
   create_table "child_profiles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "sticker_goal"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_child_profiles_on_user_id"
+    t.index [ "user_id" ], name: "index_child_profiles_on_user_id"
+  end
+
+  create_table "faultline_error_contexts", force: :cascade do |t|
+    t.integer "error_occurrence_id", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "error_occurrence_id", "key" ], name: "index_faultline_error_contexts_on_error_occurrence_id_and_key"
+    t.index [ "error_occurrence_id" ], name: "index_faultline_error_contexts_on_error_occurrence_id"
+  end
+
+  create_table "faultline_error_groups", force: :cascade do |t|
+    t.string "fingerprint", null: false
+    t.string "exception_class", null: false
+    t.text "sanitized_message", null: false
+    t.string "file_path"
+    t.integer "line_number"
+    t.string "method_name"
+    t.integer "occurrences_count", default: 0
+    t.datetime "first_seen_at"
+    t.datetime "last_seen_at"
+    t.string "status", default: "unresolved"
+    t.datetime "resolved_at"
+    t.datetime "last_notified_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "exception_class" ], name: "index_faultline_error_groups_on_exception_class"
+    t.index [ "fingerprint" ], name: "index_faultline_error_groups_on_fingerprint", unique: true
+    t.index [ "last_seen_at" ], name: "index_faultline_error_groups_on_last_seen_at"
+    t.index [ "status" ], name: "index_faultline_error_groups_on_status"
+  end
+
+  create_table "faultline_error_occurrences", force: :cascade do |t|
+    t.integer "error_group_id", null: false
+    t.string "exception_class", null: false
+    t.text "message", null: false
+    t.text "backtrace"
+    t.string "request_method"
+    t.string "request_url"
+    t.text "request_params"
+    t.text "request_headers"
+    t.string "user_agent"
+    t.string "ip_address"
+    t.bigint "user_id"
+    t.string "user_type"
+    t.string "session_id"
+    t.string "environment"
+    t.string "hostname"
+    t.string "process_id"
+    t.json "local_variables"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "created_at" ], name: "index_faultline_error_occurrences_on_created_at"
+    t.index [ "error_group_id", "created_at" ], name: "idx_on_error_group_id_created_at_98b32c40ac"
+    t.index [ "error_group_id" ], name: "index_faultline_error_occurrences_on_error_group_id"
+    t.index [ "user_type", "user_id" ], name: "index_faultline_error_occurrences_on_user_type_and_user_id"
+  end
+
+  create_table "faultline_request_profiles", force: :cascade do |t|
+    t.integer "request_trace_id", null: false
+    t.text "profile_data", null: false
+    t.string "mode", default: "cpu"
+    t.integer "samples", default: 0
+    t.float "interval_ms"
+    t.datetime "created_at", null: false
+    t.index [ "request_trace_id" ], name: "index_faultline_request_profiles_on_request_trace_id"
+  end
+
+  create_table "faultline_request_traces", force: :cascade do |t|
+    t.string "endpoint", null: false
+    t.string "http_method", null: false
+    t.string "path"
+    t.integer "status"
+    t.float "duration_ms"
+    t.float "db_runtime_ms"
+    t.float "view_runtime_ms"
+    t.integer "db_query_count", default: 0
+    t.datetime "created_at", null: false
+    t.json "spans"
+    t.boolean "has_profile", default: false
+    t.index [ "created_at" ], name: "index_faultline_request_traces_on_created_at"
+    t.index [ "endpoint", "created_at" ], name: "index_faultline_request_traces_on_endpoint_and_created_at"
+    t.index [ "endpoint" ], name: "index_faultline_request_traces_on_endpoint"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -26,8 +110,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_120002) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["token"], name: "index_sessions_on_token", unique: true
-    t.index ["user_id"], name: "index_sessions_on_user_id"
+    t.index [ "token" ], name: "index_sessions_on_token", unique: true
+    t.index [ "user_id" ], name: "index_sessions_on_user_id"
   end
 
   create_table "sticker_cards", force: :cascade do |t|
@@ -37,8 +121,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_120002) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "completed_at"
-    t.index ["child_profile_id"], name: "index_sticker_cards_on_child_profile_id"
-    t.index ["completed_at"], name: "index_sticker_cards_on_completed_at"
+    t.index [ "child_profile_id" ], name: "index_sticker_cards_on_child_profile_id"
+    t.index [ "completed_at" ], name: "index_sticker_cards_on_completed_at"
   end
 
   create_table "stickers", force: :cascade do |t|
@@ -49,7 +133,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_120002) do
     t.integer "giver_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["sticker_card_id"], name: "index_stickers_on_sticker_card_id"
+    t.index [ "sticker_card_id" ], name: "index_stickers_on_sticker_card_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -65,6 +149,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_120002) do
   end
 
   add_foreign_key "child_profiles", "users"
+  add_foreign_key "faultline_error_contexts", "faultline_error_occurrences", column: "error_occurrence_id"
+  add_foreign_key "faultline_error_occurrences", "faultline_error_groups", column: "error_group_id"
+  add_foreign_key "faultline_request_profiles", "faultline_request_traces", column: "request_trace_id", on_delete: :cascade
   add_foreign_key "sessions", "users"
   add_foreign_key "sticker_cards", "child_profiles"
   add_foreign_key "stickers", "sticker_cards"


### PR DESCRIPTION
## Summary

Integrate dlt/faultline gem for self-hosted error tracking with admin dashboard. Configures authentication to restrict dashboard access to admin users, ignores benign exceptions, and skips asset/health check paths.

## Test Plan

- [ ] Visit /faultline and verify it redirects non-admin users
- [ ] Log in as admin and verify the dashboard is accessible
- [ ] Trigger a test exception and confirm it appears in the dashboard
- [ ] Verify /up health checks do not generate tracking noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)