### PR TITLE
Add admin dashboard and user management

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,8 @@
   "version": "0.2",
   "language": "en",
   "words": [
-    "selenized"
+    "selenized",
+    "Faultline",
+    "faultline"
   ]
 }

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,5 @@
+class Admin::BaseController < ApplicationController
+  before_action :ensure_admin
+
+  layout "admin"
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,7 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    @users = User.all.order(created_at: :desc).limit(10)
+    @total_users = User.count
+    @admin_users = User.admin.count
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,54 @@
+class Admin::UsersController < Admin::BaseController
+  before_action :set_user, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @users = User.all.order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_user_path(@user), notice: t(".success")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: t(".success")
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @user == Current.user
+      redirect_to admin_users_path, alert: t(".cannot_delete_self")
+    else
+      @user.destroy
+      redirect_to admin_users_path, notice: t(".success")
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :role, :password, :password_confirmation)
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,40 @@
+<h1><%= t(".title") %></h1>
+
+<section>
+  <h2><%= t(".summary") %></h2>
+  <dl>
+    <dt><%= t(".total_users") %></dt>
+    <dd><%= @total_users %></dd>
+
+    <dt><%= t(".admin_users") %></dt>
+    <dd><%= @admin_users %></dd>
+  </dl>
+</section>
+
+<section>
+  <h2><%= t(".recent_signups") %></h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th><%= t(".email") %></th>
+        <th><%= t(".role") %></th>
+        <th><%= t(".created_at") %></th>
+        <th><%= t(".actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.email %></td>
+          <td><%= user.role %></td>
+          <td><%= l(user.created_at, format: :long) %></td>
+          <td>
+            <%= link_to t(".view"), admin_user_path(user) %>
+            <%= link_to t(".edit"), edit_admin_user_path(user) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with model: user, url: url do |form| %>
+  <% if user.errors.any? %>
+    <aside role="alert">
+      <h2><%= t("errors.template.header", count: user.errors.count) %></h2>
+      <ul>
+        <% user.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </aside>
+  <% end %>
+
+  <fieldset>
+    <label for="user_email"><%= t(".email") %></label>
+    <%= form.email_field :email, required: true %>
+
+    <label for="user_role"><%= t(".role") %></label>
+    <%= form.select :role, User.roles.keys.map { |r| [r, r] }, {}, required: true %>
+
+    <label for="user_password"><%= t(".password") %></label>
+    <%= form.password_field :password, required: user.new_record? %>
+
+    <label for="user_password_confirmation"><%= t(".password_confirmation") %></label>
+    <%= form.password_field :password_confirmation, required: user.new_record? %>
+  </fieldset>
+
+  <nav>
+    <%= form.submit submit_label %>
+    <%= link_to t(".cancel"), cancel_path %>
+  </nav>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,7 @@
+<h1><%= t(".title") %></h1>
+
+<%= render "form",
+           user: @user,
+           url: admin_user_path(@user),
+           submit_label: t(".submit"),
+           cancel_path: admin_user_path(@user) %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,28 @@
+<h1><%= t(".title") %></h1>
+
+<p><%= link_to t(".new_user"), new_admin_user_path %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= t(".email") %></th>
+      <th><%= t(".role") %></th>
+      <th><%= t(".created_at") %></th>
+      <th><%= t(".actions") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.email %></td>
+        <td><%= user.role %></td>
+        <td><%= l(user.created_at, format: :long) %></td>
+        <td>
+          <%= link_to t(".view"), admin_user_path(user) %>
+          <%= link_to t(".edit"), edit_admin_user_path(user) %>
+          <%= button_to t(".delete"), admin_user_path(user), method: :delete, data: { turbo_confirm: t(".confirm_delete") } unless user == Current.user %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,7 @@
+<h1><%= t(".title") %></h1>
+
+<%= render "form",
+           user: @user,
+           url: admin_users_path,
+           submit_label: t(".submit"),
+           cancel_path: admin_users_path %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,20 @@
+<h1><%= t(".title") %></h1>
+
+<dl>
+  <dt><%= t(".email") %></dt>
+  <dd><%= @user.email %></dd>
+
+  <dt><%= t(".role") %></dt>
+  <dd><%= @user.role %></dd>
+
+  <dt><%= t(".created_at") %></dt>
+  <dd><%= l(@user.created_at, format: :long) %></dd>
+
+  <dt><%= t(".active_sessions") %></dt>
+  <dd><%= @user.sessions.count %></dd>
+</dl>
+
+<nav>
+  <%= link_to t(".edit"), edit_admin_user_path(@user) %>
+  <%= link_to t(".back"), admin_users_path %>
+</nav>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Admin - <%= Rails.application.class.module_parent_name %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="turbo-cache-control" content="no-cache">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body>
+    <header>
+      <nav>
+        <%= link_to t("admin.nav.dashboard"), admin_root_path %>
+        <%= link_to t("admin.nav.users"), admin_users_path %>
+        <%= link_to t("admin.nav.faultline"), faultline.root_path %>
+        <%= link_to t("admin.nav.back_to_site"), root_path %>
+      </nav>
+    </header>
+
+    <main>
+      <% if flash[:notice] %>
+        <p role="status"><%= flash[:notice] %></p>
+      <% end %>
+
+      <% if flash[:alert] %>
+        <p role="alert"><%= flash[:alert] %></p>
+      <% end %>
+
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,3 +79,62 @@ en:
       black: "Black"
       selenized_dark: "Selenized Dark"
     save: "Save Preferences"
+  admin:
+    title: "Admin"
+    nav:
+      dashboard: "Dashboard"
+      users: "Users"
+      faultline: "Faultline"
+      back_to_site: "Back to Site"
+    dashboard:
+      index:
+        title: "Dashboard"
+        summary: "Summary"
+        total_users: "Total Users"
+        admin_users: "Admin Users"
+        recent_signups: "Recent Signups"
+        email: "Email"
+        role: "Role"
+        created_at: "Created"
+        actions: "Actions"
+        view: "View"
+        edit: "Edit"
+    users:
+      index:
+        title: "User Management"
+        new_user: "New User"
+        email: "Email"
+        role: "Role"
+        created_at: "Created"
+        actions: "Actions"
+        view: "View"
+        edit: "Edit"
+        delete: "Delete"
+        confirm_delete: "Are you sure you want to delete this user?"
+      show:
+        title: "User Details"
+        email: "Email"
+        role: "Role"
+        created_at: "Created"
+        active_sessions: "Active Sessions"
+        edit: "Edit"
+        back: "Back"
+      new:
+        title: "New User"
+        submit: "Create User"
+      form:
+        email: "Email"
+        role: "Role"
+        password: "Password"
+        password_confirmation: "Confirm Password"
+        cancel: "Cancel"
+      create:
+        success: "User created successfully"
+      edit:
+        title: "Edit User"
+        submit: "Update User"
+      update:
+        success: "User updated successfully"
+      destroy:
+        success: "User deleted successfully"
+        cannot_delete_self: "You cannot delete yourself"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -79,3 +79,62 @@ nl:
       black: "Zwart"
       selenized_dark: "Selenized Donker"
     save: "Voorkeuren Opslaan"
+  admin:
+    title: "Beheer"
+    nav:
+      dashboard: "Dashboard"
+      users: "Gebruikers"
+      faultline: "Faultline"
+      back_to_site: "Terug naar site"
+    dashboard:
+      index:
+        title: "Dashboard"
+        summary: "Overzicht"
+        total_users: "Totaal gebruikers"
+        admin_users: "Admin-gebruikers"
+        recent_signups: "Recente aanmeldingen"
+        email: "E-mail"
+        role: "Rol"
+        created_at: "Aangemaakt"
+        actions: "Acties"
+        view: "Bekijken"
+        edit: "Bewerken"
+    users:
+      index:
+        title: "Gebruikersbeheer"
+        new_user: "Nieuwe gebruiker"
+        email: "E-mail"
+        role: "Rol"
+        created_at: "Aangemaakt"
+        actions: "Acties"
+        view: "Bekijken"
+        edit: "Bewerken"
+        delete: "Verwijderen"
+        confirm_delete: "Weet je zeker dat je deze gebruiker wilt verwijderen?"
+      show:
+        title: "Gebruikersdetails"
+        email: "E-mail"
+        role: "Rol"
+        created_at: "Aangemaakt"
+        active_sessions: "Actieve sessies"
+        edit: "Bewerken"
+        back: "Terug"
+      new:
+        title: "Nieuwe gebruiker"
+        submit: "Gebruiker aanmaken"
+      form:
+        email: "E-mail"
+        role: "Rol"
+        password: "Wachtwoord"
+        password_confirmation: "Bevestig wachtwoord"
+        cancel: "Annuleren"
+      create:
+        success: "Gebruiker succesvol aangemaakt"
+      edit:
+        title: "Gebruiker bewerken"
+        submit: "Gebruiker bijwerken"
+      update:
+        success: "Gebruiker succesvol bijgewerkt"
+      destroy:
+        success: "Gebruiker succesvol verwijderd"
+        cannot_delete_self: "Je kunt jezelf niet verwijderen"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   mount Faultline::Engine, at: "/faultline"
+
+  namespace :admin do
+    root "dashboard#index"
+    resources :users
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   root "sessions#new"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,9 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+user:
+  email: user@example.com
+  password_digest: <%= BCrypt::Password.create("password") %>
+  role: 0
 
-one:
-  email: MyString
-  password_digest: MyString
-  role: 1
-
-two:
-  email: MyString
-  password_digest: MyString
-  role: 1
+admin:
+  email: admin@example.com
+  password_digest: <%= BCrypt::Password.create("password") %>
+  role: 2

--- a/test/integration/admin/dashboard_test.rb
+++ b/test/integration/admin/dashboard_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Admin::DashboardTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin)
+    @user = users(:user)
+  end
+
+  test "non-admin user is redirected away" do
+    sign_in_as(@user)
+    get admin_root_path
+
+    assert_redirected_to root_path
+  end
+
+  test "admin can access dashboard and sees user table" do
+    sign_in_as(@admin)
+    get admin_root_path
+
+    assert_response :success
+    assert_select "table"
+    assert_select "td", text: @admin.email
+  end
+
+  test "dashboard shows user counts" do
+    sign_in_as(@admin)
+    get admin_root_path
+
+    assert_response :success
+    assert_select "dd", text: User.count.to_s
+    assert_select "dd", text: User.admin.count.to_s
+  end
+end

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Admin::UsersTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin)
+    @user = users(:user)
+  end
+
+  test "admin can list users" do
+    sign_in_as(@admin)
+    get admin_users_path
+
+    assert_response :success
+    assert_select "td", text: @user.email
+  end
+
+  test "admin can view a user" do
+    sign_in_as(@admin)
+    get admin_user_path(@user)
+
+    assert_response :success
+    assert_select "dd", text: @user.email
+  end
+
+  test "admin can reach new user form" do
+    sign_in_as(@admin)
+    get new_admin_user_path
+
+    assert_response :success
+    assert_select "form"
+  end
+
+  test "admin can create a user" do
+    sign_in_as(@admin)
+
+    assert_difference("User.count", 1) do
+      post admin_users_path, params: {
+        user: {
+          email: "created@example.com",
+          role: "parent",
+          password: "password",
+          password_confirmation: "password"
+        }
+      }
+    end
+
+    created_user = User.find_by!(email: "created@example.com")
+    assert_redirected_to admin_user_path(created_user)
+  end
+
+  test "admin can edit a user" do
+    sign_in_as(@admin)
+    get edit_admin_user_path(@user)
+
+    assert_response :success
+    assert_select "form"
+  end
+
+  test "admin can update a user" do
+    sign_in_as(@admin)
+    patch admin_user_path(@user), params: { user: { role: "admin" } }
+
+    assert_redirected_to admin_user_path(@user)
+    assert_equal "admin", @user.reload.role
+  end
+
+  test "admin cannot delete themselves" do
+    sign_in_as(@admin)
+
+    assert_no_difference("User.count") do
+      delete admin_user_path(@admin)
+    end
+
+    assert_redirected_to admin_users_path
+  end
+
+  test "non-admin user is redirected for all actions" do
+    sign_in_as(@user)
+
+    get admin_users_path
+    assert_redirected_to root_path
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Admin::DashboardController` with user counts (total, admin) and recent signups table
- Adds `Admin::UsersController` with full CRUD (index, show, new, create, edit, update, destroy)
- Adds admin layout, views, and i18n keys (en + nl)
- Updates test fixtures and adds integration tests for dashboard and users

## Test plan
- [ ] Sign in as an admin user and visit `/admin`
- [ ] Verify dashboard shows correct user counts and recent signups table
- [ ] Visit `/admin/users` and verify all users are listed
- [ ] Create a new user via `/admin/users/new`
- [ ] Edit an existing user's role
- [ ] Verify non-admin users are redirected to root
- [ ] Verify admin cannot delete themselves
- [ ] Run `bin/rails test test/integration/admin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)