### PR TITLE
Add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
## Summary
- Adds `cooldown.default-days: 7` to both the `bundler` and `github-actions` Dependabot ecosystems in `.github/dependabot.yml`, so Dependabot waits a week after a release before opening an update PR.

## Test plan
- [ ] Confirm Dependabot picks up the new config on its next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)