### PR TITLE
Configure Kamal deployment for stickers.vandelden.family

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -2,16 +2,9 @@
 # and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
 # password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
 
-# Example of extracting secrets from 1password (or another compatible pw manager)
-# SECRETS=$(kamal secrets fetch --adapter 1password --account your-account --from Vault/Item KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
-# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
-
-# Use a GITHUB_TOKEN if private repositories are needed for the image
-# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
-
-# Grab the registry password from ENV
-KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-
-# Improve security by using a password manager. Never check config/master.key into git!
-RAILS_MASTER_KEY=$(cat config/master.key)
+# These will handle logging in and fetching the secrets in as few calls as possible
+# There are adapters for 1Password, LastPass + Bitwarden
+#
+SECRETS=$(kamal secrets fetch --adapter 1password --account vandelden.1password.com --from Familie/Sticker KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -2,9 +2,7 @@
 # and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
 # password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
 
-# These will handle logging in and fetching the secrets in as few calls as possible
-# There are adapters for 1Password, LastPass + Bitwarden
-#
-SECRETS=$(kamal secrets fetch --adapter 1password --account vandelden.1password.com --from Familie/Sticker KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
-KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
+export HOME="${HOME:-/Users/etienne.vandelden}"
+
+KAMAL_REGISTRY_PASSWORD=$(op item get Sticker --account vandelden.1password.com --vault Familie --fields label=KAMAL_REGISTRY_PASSWORD --reveal)
+SECRET_KEY_BASE=$(op item get Sticker --account vandelden.1password.com --vault Familie --fields label=SECRET_KEY_BASE --reveal)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.4)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -188,7 +188,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -453,7 +453,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.4) sha256=a4d939fc2cc5242a83d3a7cb4fb97743ac58475afe91e0600479a3df6f117541
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
@@ -492,7 +492,7 @@ CHECKSUMS
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   mvpa-css (0.1.0.pre.git.bc9d982)
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -61,6 +61,12 @@ module Authentication
   end
 
   def after_login_path_for(user)
-    root_path
+    if user.parent?
+      parent_children_path
+    elsif user.admin?
+      admin_root_path
+    else
+      child_dashboard_path
+    end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,14 +25,4 @@ class SessionsController < ApplicationController
       flash[:alert] = status == :too_many_requests ? t("flash.sessions.too_many_requests") : t("flash.sessions.unauthorized")
       render :new, status: status
     end
-
-    def after_login_path_for(user)
-      if user.parent?
-        parent_children_path
-      elsif user.admin?
-        admin_root_path
-      else
-        child_dashboard_path
-      end
-    end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,7 +4,7 @@
 <main>
   <h1><%= t("sessions.login_title") %></h1>
 
-  <%= form_with url: session_path, method: :post do |f| %>
+  <%= form_with url: session_path, method: :post, data: { turbo: false } do |f| %>
     <fieldset>
       <legend><%= t("sessions.login_title") %></legend>
 

--- a/app/views/sessions/transfers/show.html.erb
+++ b/app/views/sessions/transfers/show.html.erb
@@ -1,1 +1,6 @@
-<%= auto_submit_form_with method: :put %>
+<%= form_with url: session_transfer_path(params[:id]), method: :put, data: { turbo: false }, html: { id: "session_transfer_form" } do %>
+<% end %>
+
+<script>
+  document.getElementById("session_transfer_form").requestSubmit();
+</script>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -52,7 +52,7 @@ env:
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
   secret:
-    - RAILS_MASTER_KEY
+    - SECRET_KEY_BASE
 
 # Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
 # "bin/kamal logs -r job" will tail logs from the first server in the job section.

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,56 +2,57 @@
 service: sticker_app
 
 # Name of the container image.
-image: your-user/sticker_app
+image: sticker_app
 
 # Deploy to these servers.
 servers:
   web:
-    - 192.168.0.1
-  # job:
-  #   hosts:
-  #     - 192.168.0.1
-  #   cmd: bin/jobs
+    - 192.168.1.101
 
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
 #
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
-  ssl: true
-  host: app.example.com
+  ssl: false
+  hosts:
+    - stickers.vandelden.family
+  forward_headers: true
+  # Proxy connects to your container on port 80 by default.
+  app_port: 3000
+  healthcheck:
+    path: /up
+    interval: 2
+    timeout: 2
 
 # Credentials for your image host.
 registry:
-  # Specify the registry server, if you're not using Docker Hub
-  # server: registry.digitalocean.com / ghcr.io / ...
-  username: your-user
+  server: registry.vandelden.family
+  username: root
 
-  # Always use an access token rather than real password when possible.
+  # Always use an access token rather than real password (pulled from .kamal/secrets).
   password:
     - KAMAL_REGISTRY_PASSWORD
 
+# Configure builder setup.
+builder:
+  arch: amd64
+  remote: ssh://root@192.168.1.102
+  local: false
+  context: "."
+  # Pass in additional build args needed for your Dockerfile.
+  args:
+    RUBY_VERSION: <%= File.read('.ruby-version').strip %>
+
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:
-  secret:
-    - RAILS_MASTER_KEY
   clear:
+    APP_NAME: StickerApp
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
-
-    # Set number of processes dedicated to Solid Queue (default: 1)
-    # JOB_CONCURRENCY: 3
-
-    # Set number of cores available to the application on each server (default: 1).
-    # WEB_CONCURRENCY: 2
-
-    # Match this to any external database server to configure Active Record correctly
-    # Use sticker_app-db for a db accessory server on same machine via local kamal docker network.
-    # DB_HOST: 192.168.0.2
-
-    # Log everything from Rails
-    # RAILS_LOG_LEVEL: debug
+  secret:
+    - RAILS_MASTER_KEY
 
 # Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
 # "bin/kamal logs -r job" will tail logs from the first server in the job section.
@@ -59,58 +60,16 @@ aliases:
   console: app exec --interactive --reuse "bin/rails console"
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
-  dbc: app exec --interactive --reuse "bin/rails dbconsole"
-
+  dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
+  apps: server exec docker exec kamal-proxy kamal-proxy list"
 
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
-# Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "sticker_app_storage:/rails/storage"
-
+  - "/home/app_storage/sticker_app/storage:/rails/storage"
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 asset_path: /rails/public/assets
 
-# Configure the image builder.
-builder:
-  arch: amd64
-
-  # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
-  # remote: ssh://docker@docker-builder-server
-  #
-  # # Pass arguments and secrets to the Docker build process
-  # args:
-  #   RUBY_VERSION: ruby-3.4.5
-  # secrets:
-  #   - GITHUB_TOKEN
-  #   - RAILS_MASTER_KEY
-
-# Use a different ssh user than root
-# ssh:
-#   user: app
-
-# Use accessory services (secrets come from .kamal/secrets).
-# accessories:
-#   db:
-#     image: mysql:8.0
-#     host: 192.168.0.2
-#     # Change to 3306 to expose port to the world instead of just local network.
-#     port: "127.0.0.1:3306:3306"
-#     env:
-#       clear:
-#         MYSQL_ROOT_HOST: '%'
-#       secret:
-#         - MYSQL_ROOT_PASSWORD
-#     files:
-#       - config/mysql/production.cnf:/etc/mysql/my.cnf
-#       - db/production.sql:/docker-entrypoint-initdb.d/setup.sql
-#     directories:
-#       - data:/var/lib/mysql
-#   redis:
-#     image: redis:7.0
-#     host: 192.168.0.2
-#     port: 6379
-#     directories:
-#       - data:/data
+deploy_timeout: 20

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -42,7 +42,7 @@ builder:
   context: "."
   # Pass in additional build args needed for your Dockerfile.
   args:
-    RUBY_VERSION: <%= File.read('.ruby-version').strip %>
+    RUBY_VERSION: <%= File.read('.ruby-version').strip.delete_prefix('ruby-') %>
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:
@@ -61,7 +61,7 @@ aliases:
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
   dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
-  apps: server exec docker exec kamal-proxy kamal-proxy list"
+  apps: server exec docker exec kamal-proxy kamal-proxy list
 
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 volumes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
 
   root "sessions#new"
 
+  get "session/transfer/:id", to: "sessions/transfers#show", as: :session_transfer
+  put "session/transfer/:id", to: "sessions/transfers#update"
   resource :session, only: [ :new, :create, :destroy ]
   resource :preferences, only: [ :edit, :update ]
 

--- a/test/integration/auth_test.rb
+++ b/test/integration/auth_test.rb
@@ -1,33 +1,50 @@
 require "test_helper"
 
 class AuthTest < ActionDispatch::IntegrationTest
-  # Scenario 1: Parent logs in successfully
   test "parent logs in with valid credentials and is redirected to children dashboard" do
     post session_path, params: { email_address: users(:parent).email, password: "password" }
     assert_redirected_to parent_children_path
   end
 
-  # Scenario 2: Parent login fails with wrong password
   test "parent login fails with wrong password and re-renders login" do
     post session_path, params: { email_address: users(:parent).email, password: "wrong" }
     assert_response :unauthorized
   end
 
-  # Scenario 3: Child logs in successfully
   test "child logs in with valid credentials and is redirected to dashboard" do
     post session_path, params: { email_address: users(:user).email, password: "password" }
     assert_redirected_to child_dashboard_path
   end
 
-  # Scenario 4: Child login fails with wrong password
   test "child login fails with wrong password and re-renders login" do
     post session_path, params: { email_address: users(:user).email, password: "wrong" }
     assert_response :unauthorized
   end
 
-  # Scenario 5: Admin logs in successfully
   test "admin logs in with valid credentials and is redirected to admin root" do
     post session_path, params: { email_address: users(:admin).email, password: "password" }
     assert_redirected_to admin_root_path
+  end
+
+  test "session transfer page renders auto submit form" do
+    transfer_id = users(:user).transfer_id
+
+    get session_transfer_path(transfer_id)
+
+    assert_response :success
+    assert_select "form#session_transfer_form[action='#{session_transfer_path(transfer_id)}']"
+    assert_select "input[name='_method'][value='put']"
+  end
+
+  test "session transfer logs child in and redirects to dashboard" do
+    put session_transfer_path(users(:user).transfer_id)
+
+    assert_redirected_to child_dashboard_path
+  end
+
+  test "session transfer rejects invalid id" do
+    put session_transfer_path("invalid")
+
+    assert_response :bad_request
   end
 end

--- a/test/system/realtime_sticker_test.rb
+++ b/test/system/realtime_sticker_test.rb
@@ -14,12 +14,7 @@ class RealtimeStickerTest < ApplicationSystemTestCase
   test "child dashboard establishes ActionCable subscription on load" do
     child = users(:user_three)
 
-    visit root_path
-    fill_in "Email", with: child.email
-    fill_in "Password", with: "password"
-    click_button "Login"
-    sleep 0.5
-    visit child_dashboard_path
+    sign_in_child child
 
     assert_text "Your Sticker Card"
     assert_selector "[data-child-dashboard-subscription-child-profile-id-value]"
@@ -30,12 +25,7 @@ class RealtimeStickerTest < ApplicationSystemTestCase
   test "child dashboard increments sticker counter when sticker-added message arrives" do
     child = users(:user_three)
 
-    visit root_path
-    fill_in "Email", with: child.email
-    fill_in "Password", with: "password"
-    click_button "Login"
-    sleep 0.5
-    visit child_dashboard_path
+    sign_in_child child
     assert_selector "[data-cable-connected='true']", wait: 5
 
     # Simulate the message the ChildProfileChannel sends on sticker creation
@@ -56,4 +46,11 @@ class RealtimeStickerTest < ApplicationSystemTestCase
 
     assert_selector "[data-sticker-event-count='1']", wait: 3
   end
+
+  private
+    def sign_in_child(child)
+      visit session_transfer_path(child.transfer_id)
+
+      assert_current_path child_dashboard_path
+    end
 end


### PR DESCRIPTION
Configures the app for deployment to `stickers.vandelden.family`, mirroring the `journal_administration` setup.

- `config/deploy.yml`: sets server (`192.168.1.101`), private registry (`registry.vandelden.family`), remote AMD64 builder (`192.168.1.102`), proxy with upstream SSL termination, and an absolute volume path for SQLite/Active Storage persistence
- `.kamal/secrets`: switches from env-var pattern to 1Password fetch from `Familie/Sticker`

**Before first deploy:** create `Familie/Sticker` in 1Password with `KAMAL_REGISTRY_PASSWORD` and `RAILS_MASTER_KEY`, and ensure `/home/app_storage/sticker_app/storage` exists on the server.