### PR TITLE
Add locale and account settings to preferences page

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -53,7 +53,7 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation)
+    params.require(:user).permit(:email, :password, :password_confirmation, :locale)
   end
 
   def assign_role(user)

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -17,6 +17,10 @@ class PreferencesController < ApplicationController
   private
 
   def preferences_params
-    params.require(:user).permit(:locale, :color_scheme, :light_theme, :dark_theme)
+    permitted = params.require(:user).permit(
+      :email, :password, :password_confirmation,
+      :locale, :color_scheme, :light_theme, :dark_theme
+    )
+    permitted[:password].blank? ? permitted.except(:password, :password_confirmation) : permitted
   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -24,7 +24,7 @@
     <%= form.password_field :password_confirmation, required: user.new_record? %>
 
     <label for="user_locale"><%= t(".locale") %></label>
-    <%= form.select :locale, [["English", "en"], ["Nederlands", "nl"], ["Italiano", "it"]] %>
+    <%= form.select :locale, %w[en nl it].map { |locale| [t("locale_names.#{locale}"), locale] } %>
   </fieldset>
 
   <nav>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -22,6 +22,9 @@
 
     <label for="user_password_confirmation"><%= t(".password_confirmation") %></label>
     <%= form.password_field :password_confirmation, required: user.new_record? %>
+
+    <label for="user_locale"><%= t(".locale") %></label>
+    <%= form.select :locale, [["English", "en"], ["Nederlands", "nl"], ["Italiano", "it"]] %>
   </fieldset>
 
   <nav>

--- a/app/views/child/dashboard/show.html.erb
+++ b/app/views/child/dashboard/show.html.erb
@@ -3,6 +3,7 @@
   <header>
     <h1><%= t("child.dashboard.title") %></h1>
     <nav>
+      <%= link_to t("navigation.preferences"), edit_preferences_path %>
       <%= button_to t("common.logout"), session_path, method: :delete %>
     </nav>
   </header>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -19,6 +19,7 @@
           <li><%= link_to t("admin.nav.dashboard"), admin_root_path, "aria-current": (current_page?(admin_root_path) ? "page" : nil) %></li>
           <li><%= link_to t("admin.nav.users"), admin_users_path, "aria-current": (request.path.start_with?("/admin/users") ? "page" : nil) %></li>
           <li><%= link_to t("admin.nav.faultline"), faultline.root_path %></li>
+          <li><%= link_to t("navigation.preferences"), edit_preferences_path %></li>
           <li><%= link_to t("admin.nav.back_to_site"), root_path %></li>
         </ul>
       </nav>

--- a/app/views/parent/children/index.html.erb
+++ b/app/views/parent/children/index.html.erb
@@ -5,6 +5,7 @@
       <% if Current.user.admin? %>
         <%= link_to t("navigation.admin"), admin_root_path %>
       <% end %>
+      <%= link_to t("navigation.preferences"), edit_preferences_path %>
       <%= button_to t("common.logout"), session_path, method: :delete %>
     </nav>
   </header>

--- a/app/views/preferences/edit.html.erb
+++ b/app/views/preferences/edit.html.erb
@@ -3,6 +3,25 @@
 
   <%= form_with model: @user, url: preferences_path, method: :patch, local: true do |f| %>
     <fieldset>
+      <legend><%= t("preferences.account_label") %></legend>
+
+      <div>
+        <%= f.label :email, t("preferences.email") %>
+        <%= f.email_field :email %>
+      </div>
+
+      <div>
+        <%= f.label :password, t("preferences.password") %>
+        <%= f.password_field :password, placeholder: t("preferences.password_placeholder") %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, t("preferences.password_confirmation") %>
+        <%= f.password_field :password_confirmation %>
+      </div>
+    </fieldset>
+
+    <fieldset>
       <legend><%= t("preferences.language_label") %></legend>
       <%= f.label :locale %>
       <%= f.select :locale, [["English", "en"], ["Nederlands", "nl"], ["Italiano", "it"]], {}, { class: "form-control" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,11 @@ en:
     password: Password
   preferences:
     title: "Preferences"
+    account_label: "Account"
+    email: "Email"
+    password: "Password"
+    password_placeholder: "Leave blank to keep current password"
+    password_confirmation: "Confirm Password"
     language_label: "Language"
     theme_label: "Theme"
     color_scheme:
@@ -129,6 +134,7 @@ en:
         role: "Role"
         password: "Password"
         password_confirmation: "Confirm Password"
+        locale: "Language"
         cancel: "Cancel"
       create:
         success: "User created successfully"
@@ -142,3 +148,4 @@ en:
         cannot_delete_self: "You cannot delete yourself"
   navigation:
     admin: "Admin"
+    preferences: "Preferences"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,10 @@ en:
   common:
     logout: "Logout 🐿️"
     back: "← Back"
+  locale_names:
+    en: "English"
+    nl: "Dutch"
+    it: "Italian"
   errors:
     authentication_required: "Please log in"
     admin_required: "Admin access required"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -17,6 +17,10 @@ it:
   common:
     logout: "Esci 🐿️"
     back: "← Indietro"
+  locale_names:
+    en: "Inglese"
+    nl: "Olandese"
+    it: "Italiano"
   errors:
     authentication_required: "Effettua il login"
     admin_required: "Accesso admin richiesto"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -68,6 +68,11 @@ it:
     password: "Password"
   preferences:
     title: "Preferenze"
+    account_label: "Account"
+    email: "Email"
+    password: "Password"
+    password_placeholder: "Lascia vuoto per mantenere la password attuale"
+    password_confirmation: "Conferma Password"
     language_label: "Lingua"
     theme_label: "Tema"
     color_scheme:
@@ -129,6 +134,7 @@ it:
         role: "Ruolo"
         password: "Password"
         password_confirmation: "Conferma Password"
+        locale: "Lingua"
         cancel: "Annulla"
       create:
         success: "Utente creato con successo"
@@ -142,3 +148,4 @@ it:
         cannot_delete_self: "Non puoi eliminare te stesso"
   navigation:
     admin: "Admin"
+    preferences: "Preferenze"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -17,6 +17,10 @@ nl:
   common:
     logout: "Uitloggen 🐿️"
     back: "← Terug"
+  locale_names:
+    en: "Engels"
+    nl: "Nederlands"
+    it: "Italiaans"
   errors:
     authentication_required: "Gelieve in te loggen"
     admin_required: "Admin toegang vereist"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -68,6 +68,11 @@ nl:
     password: Wachtwoord
   preferences:
     title: "Voorkeuren"
+    account_label: "Account"
+    email: "E-mail"
+    password: "Wachtwoord"
+    password_placeholder: "Laat leeg om huidig wachtwoord te bewaren"
+    password_confirmation: "Bevestig wachtwoord"
     language_label: "Taal"
     theme_label: "Thema"
     color_scheme:
@@ -129,6 +134,7 @@ nl:
         role: "Rol"
         password: "Wachtwoord"
         password_confirmation: "Bevestig wachtwoord"
+        locale: "Taal"
         cancel: "Annuleren"
       create:
         success: "Gebruiker succesvol aangemaakt"
@@ -142,3 +148,4 @@ nl:
         cannot_delete_self: "Je kunt jezelf niet verwijderen"
   navigation:
     admin: "Beheer"
+    preferences: "Voorkeuren"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -22,3 +22,9 @@ admin:
   email: admin@example.com
   password_digest: <%= BCrypt::Password.create("password") %>
   role: 2
+
+dutch_admin:
+  email: dutch-admin@example.com
+  password_digest: <%= BCrypt::Password.create("password") %>
+  role: 2
+  locale: nl

--- a/test/integration/admin/users_test.rb
+++ b/test/integration/admin/users_test.rb
@@ -56,6 +56,16 @@ class Admin::UsersTest < ActionDispatch::IntegrationTest
     assert_select "form"
   end
 
+  test "admin user form localizes locale options" do
+    sign_in_as(users(:dutch_admin))
+    get edit_admin_user_path(@user)
+
+    assert_response :success
+    assert_select "option", text: I18n.t("locale_names.en", locale: :nl)
+    assert_select "option", text: I18n.t("locale_names.nl", locale: :nl)
+    assert_select "option", text: I18n.t("locale_names.it", locale: :nl)
+  end
+
   test "admin can update a user" do
     sign_in_as(@admin)
     patch admin_user_path(@user), params: { user: { role: "admin" } }

--- a/test/integration/admin_flow_test.rb
+++ b/test/integration/admin_flow_test.rb
@@ -53,6 +53,13 @@ class AdminFlowTest < ActionDispatch::IntegrationTest
   # There is no deactivate route — `user_params` does not permit `active`.
   # Destroy is the only admin removal path. After deletion the user record is
   # gone, so `User.active.authenticate_by` returns nil → :unauthorized.
+  test "admin layout nav renders a link to preferences" do
+    sign_in_as @admin
+    get admin_root_path
+    assert_response :success
+    assert_select "a[href='#{edit_preferences_path}']"
+  end
+
   test "admin destroys a user and the user can no longer log in" do
     target = users(:user_two)
     target_email = target.email

--- a/test/integration/child_flow_test.rb
+++ b/test/integration/child_flow_test.rb
@@ -14,4 +14,11 @@ class ChildFlowTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "body"
   end
+
+  test "child dashboard renders a link to preferences" do
+    sign_in_as @child
+    get child_dashboard_path
+    assert_response :success
+    assert_select "a[href='#{edit_preferences_path}']"
+  end
 end

--- a/test/integration/parent_flow_test.rb
+++ b/test/integration/parent_flow_test.rb
@@ -92,6 +92,13 @@ class AdminNavTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href='#{admin_root_path}']", count: 0
   end
+
+  test "parent dashboard renders a link to preferences" do
+    sign_in_as @parent
+    get parent_children_path
+    assert_response :success
+    assert_select "a[href='#{edit_preferences_path}']"
+  end
 end
 
 class ParentHappyFlowTest < ActionDispatch::IntegrationTest

--- a/test/integration/preferences_test.rb
+++ b/test/integration/preferences_test.rb
@@ -34,4 +34,113 @@ class PreferencesTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert_equal "en", @user.reload.locale
   end
+
+  test "blank password does not change the user's password" do
+    sign_in_as(@user)
+    original_digest = @user.password_digest
+
+    patch preferences_path, params: {
+      user: {
+        locale: "en",
+        password: "",
+        password_confirmation: ""
+      }
+    }
+
+    assert_redirected_to edit_preferences_path
+    assert_equal original_digest, @user.reload.password_digest
+  end
+
+  test "non-blank password updates the user's password" do
+    sign_in_as(@user)
+
+    patch preferences_path, params: {
+      user: {
+        locale: "en",
+        password: "new-secure-pass",
+        password_confirmation: "new-secure-pass"
+      }
+    }
+
+    assert_redirected_to edit_preferences_path
+    assert @user.reload.authenticate("new-secure-pass"), "Expected password to be updated"
+  end
+
+  test "child can access preferences edit page" do
+    sign_in_as(@user)
+    get edit_preferences_path
+    assert_response :success
+  end
+
+  test "child can update locale via preferences" do
+    sign_in_as(@user)
+
+    patch preferences_path, params: { user: { locale: "nl" } }
+
+    assert_redirected_to edit_preferences_path
+    assert_equal "nl", @user.reload.locale
+  end
+
+  class ParentPreferencesTest < ActionDispatch::IntegrationTest
+    setup do
+      @parent = users(:parent)
+    end
+
+    test "parent can access preferences edit page" do
+      sign_in_as(@parent)
+      get edit_preferences_path
+      assert_response :success
+    end
+
+    test "parent can update locale via preferences" do
+      sign_in_as(@parent)
+
+      patch preferences_path, params: { user: { locale: "nl" } }
+
+      assert_redirected_to edit_preferences_path
+      assert_equal "nl", @parent.reload.locale
+    end
+  end
+
+  class AdminPreferencesTest < ActionDispatch::IntegrationTest
+    setup do
+      @admin = users(:admin)
+    end
+
+    test "admin can access preferences edit page" do
+      sign_in_as(@admin)
+      get edit_preferences_path
+      assert_response :success
+    end
+
+    test "admin can update locale via preferences" do
+      sign_in_as(@admin)
+
+      patch preferences_path, params: { user: { locale: "it" } }
+
+      assert_redirected_to edit_preferences_path
+      assert_equal "it", @admin.reload.locale
+    end
+  end
+end
+
+class AdminUserLocaleTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin)
+    @target = users(:user)
+  end
+
+  test "admin can update a user's locale" do
+    sign_in_as(@admin)
+
+    patch admin_user_path(@target), params: {
+      user: {
+        email: @target.email,
+        locale: "nl"
+      }
+    }
+
+    assert_redirected_to admin_user_path(@target)
+    assert_equal "nl", @target.reload.locale
+  end
 end


### PR DESCRIPTION
## Summary

- Preferences page now lets any user update their email, password, and locale; blank password is ignored so users can change only what they need.
- Admin user form gains a locale select and the controller permits it, so admins can set a user's preferred language.
- Preferences link added to the child dashboard, parent dashboard, and admin layout nav so the page is reachable from all three interfaces.
- Translation keys for the new fields added across all three locale files (en/nl/it).
- Integration tests cover blank/non-blank password updates, role-based preferences access, admin locale update, and nav link presence in all three layouts.

## Test plan

- [ ] Run `bundle exec rails test` — all 70 tests pass
- [ ] Log in as a child, parent, and admin; confirm preferences link appears in each nav
- [ ] Update email and locale via preferences; confirm changes persist
- [ ] Submit preferences with blank password; confirm existing password still works
- [ ] Submit preferences with a new password; confirm new password authenticates
- [ ] Edit a user as admin; confirm locale select is present and saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)