### PR TITLE
Unify email field naming

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.active.authenticate_by(email: params[:email_address], password: params[:password])
+    if user = User.active.authenticate_by(email: params[:email], password: params[:password])
       start_new_session_for user
       redirect_to post_authenticating_url
     else

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -16,6 +16,6 @@ class Users::ProfilesController < ApplicationController
 
   private
     def user_params
-      params.require(:user).permit(:name, :email_address, :password)
+      params.require(:user).permit(:name, :email, :password)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     start_new_session_for @user
     redirect_to root_url
   rescue ActiveRecord::RecordNotUnique
-    redirect_to new_session_url(email_address: user_params[:email_address])
+    redirect_to new_session_url(email: user_params[:email])
   end
 
   def update
@@ -38,6 +38,6 @@ class UsersController < ApplicationController
     end
 
     def user_params
-      params.require(:user).permit(:name, :email_address, :password)
+      params.require(:user).permit(:name, :email, :password)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   def deactivate
     transaction do
       sessions.delete_all
-      update! active: false, email_address: deactivated_email_address
+      update! active: false, email: deactivated_email
     end
   end
 
@@ -41,7 +41,7 @@ class User < ApplicationRecord
 
   private
 
-  def deactivated_email_address
-    email_address&.gsub(/@/, "-deactivated-#{SecureRandom.uuid}@")
+  def deactivated_email
+    email&.gsub(/@/, "-deactivated-#{SecureRandom.uuid}@")
   end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,8 +9,8 @@
       <legend><%= t("sessions.login_title") %></legend>
 
       <div>
-        <%= f.label :email_address, t("sessions.email") %>
-        <%= f.email_field :email_address, required: true, autocomplete: "email" %>
+        <%= f.label :email, t("sessions.email") %>
+        <%= f.email_field :email, required: true, autocomplete: "email" %>
       </div>
 
       <div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,9 +22,9 @@
       </label>
     </div>
     <div class="flex align-center gap">
-      <%= translation_button(:email_address) %>
+      <%= translation_button(:email) %>
       <label class="flex align-center gap input input--actor">
-        <%= form.email_field :email_address, class: "input full-width", autocomplete: "username", placeholder: "Email address", required: true %>
+        <%= form.email_field :email, class: "input full-width", autocomplete: "username", placeholder: "Email address", required: true %>
         <%= image_tag "email.svg", aria: { hidden: "true" }, size: 30, class: "colorize--black" %>
       </label>
     </div>

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -31,9 +31,9 @@
       </label>
     </div>
     <div class="flex align-center gap">
-      <%= translation_button(:email_address) %>
+      <%= translation_button(:email) %>
       <label class="flex align-center gap input input--actor">
-        <%= form.email_field :email_address, class: "input full-width", autocomplete: "username", placeholder: "Email address", required: true %>
+        <%= form.email_field :email, class: "input full-width", autocomplete: "username", placeholder: "Email address", required: true %>
         <%= image_tag "email.svg", aria: { hidden: "true" }, size: 30, class: "colorize--black" %>
       </label>
     </div>

--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -22,7 +22,7 @@
 
 <div class="panel margin-block-double shadow center">
   <h2 class="margin-none-block-end"><%= @user.name %></h2>
-  <p class="margin-none-block-start"><%= mail_to @user.email_address %></p>
+  <p class="margin-none-block-start"><%= mail_to @user.email %></p>
 
   <% if Current.user.can_administer? %>
     <hr class="full-width margin-block-double" aria-hidden="true">

--- a/test/integration/admin_flow_test.rb
+++ b/test/integration/admin_flow_test.rb
@@ -65,7 +65,7 @@ class AdminFlowTest < ActionDispatch::IntegrationTest
     assert_not User.exists?(target.id)
 
     delete session_path  # log out admin
-    post session_path, params: { email_address: target_email, password: "password" }
+    post session_path, params: { email: target_email, password: "password" }
     assert_redirected_to new_session_path
   end
 end

--- a/test/integration/auth_test.rb
+++ b/test/integration/auth_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class AuthTest < ActionDispatch::IntegrationTest
   test "parent logs in with valid credentials and is redirected to children dashboard" do
-    post session_path, params: { email_address: users(:parent).email, password: "password" }
+    post session_path, params: { email: users(:parent).email, password: "password" }
     assert_redirected_to parent_children_path
   end
 
   test "parent login fails with wrong password and redirects to login" do
-    post session_path, params: { email_address: users(:parent).email, password: "wrong" }
+    post session_path, params: { email: users(:parent).email, password: "wrong" }
     assert_redirected_to new_session_path
   end
 
@@ -21,17 +21,17 @@ class AuthTest < ActionDispatch::IntegrationTest
   end
 
   test "child logs in with valid credentials and is redirected to dashboard" do
-    post session_path, params: { email_address: users(:user).email, password: "password" }
+    post session_path, params: { email: users(:user).email, password: "password" }
     assert_redirected_to child_dashboard_path
   end
 
   test "child login fails with wrong password and redirects to login" do
-    post session_path, params: { email_address: users(:user).email, password: "wrong" }
+    post session_path, params: { email: users(:user).email, password: "wrong" }
     assert_redirected_to new_session_path
   end
 
   test "admin logs in with valid credentials and is redirected to parent children" do
-    post session_path, params: { email_address: users(:admin).email, password: "password" }
+    post session_path, params: { email: users(:admin).email, password: "password" }
     assert_redirected_to parent_children_path
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ end
 
 module AuthenticationTestHelper
   def sign_in_as(user, password: "password", follow_redirect: true)
-    post session_path, params: { email_address: user.email, password: password }
+    post session_path, params: { email: user.email, password: password }
     follow_redirect! if follow_redirect && response.redirect?
   end
 end


### PR DESCRIPTION
Replace all `email_address` references with `email` to match the database column name throughout the app — controllers, views, model, and tests.

This also fixes a broken `User#deactivate` method that referenced the non-existent `email_address` attribute instead of `email`, which would have raised a `NoMethodError` when deactivating a user.

No schema changes — the database column was already `email`.