### PR TITLE
Make sticker buttons always visible

### DIFF
--- a/app/views/parent/children/index.html.erb
+++ b/app/views/parent/children/index.html.erb
@@ -29,22 +29,24 @@
                 aria-label="<%= t("parent.dashboard.progress", current: total_stickers, total: needed) %>"></progress>
       <p><%= t("parent.dashboard.progress", current: total_stickers, total: needed) %></p>
 
-      <%= button_to t("parent.actions.give_sticker"), parent_child_sticker_path(child),
-                    method: :post,
-                    params: { emoji_mode: "random" },
-                    class: "button-success" %>
+      <footer>
+        <%= button_to t("parent.actions.give_sticker"), parent_child_sticker_path(child),
+                      method: :post,
+                      params: { emoji_mode: "random" },
+                      class: "button-success" %>
 
-      <%= button_to t("parent.actions.give_penalty"), parent_child_penalty_path(child),
-                    method: :post,
-                    class: "button-danger" %>
+        <%= button_to t("parent.actions.give_penalty"), parent_child_penalty_path(child),
+                      method: :post,
+                      class: "button-danger" %>
 
-      <%= link_to t("parent.actions.view_history"), parent_child_history_path(child) %>
+        <%= link_to t("parent.actions.view_history"), parent_child_history_path(child) %>
 
-      <% if rewardable_card %>
-        <p><%= t("parent.dashboard.card_completed") %></p>
-        <%= button_to t("parent.actions.mark_rewarded"), parent_child_reward_path(child),
-                      method: :post, class: "button-success" %>
-      <% end %>
+        <% if rewardable_card %>
+          <p><%= t("parent.dashboard.card_completed") %></p>
+          <%= button_to t("parent.actions.mark_rewarded"), parent_child_reward_path(child),
+                        method: :post, class: "button-success" %>
+        <% end %>
+      </footer>
     </article>
   <% end %>
 

--- a/app/views/parent/children/index.html.erb
+++ b/app/views/parent/children/index.html.erb
@@ -29,21 +29,21 @@
                 aria-label="<%= t("parent.dashboard.progress", current: total_stickers, total: needed) %>"></progress>
       <p><%= t("parent.dashboard.progress", current: total_stickers, total: needed) %></p>
 
+      <%= button_to t("parent.actions.give_sticker"), parent_child_sticker_path(child),
+                    method: :post,
+                    params: { emoji_mode: "random" },
+                    class: "button-success" %>
+
+      <%= button_to t("parent.actions.give_penalty"), parent_child_penalty_path(child),
+                    method: :post,
+                    class: "button-danger" %>
+
+      <%= link_to t("parent.actions.view_history"), parent_child_history_path(child) %>
+
       <% if rewardable_card %>
-        <%= button_to t("parent.actions.mark_rewarded"), parent_child_reward_path(child), method: :post, class: "button-success" %>
-      <% else %>
-        <footer>
-          <%= button_to t("parent.actions.give_sticker"), parent_child_sticker_path(child),
-                        method: :post,
-                        params: { emoji_mode: "random" },
-                        class: "button-success" %>
-
-          <%= button_to t("parent.actions.give_penalty"), parent_child_penalty_path(child),
-                        method: :post,
-                        class: "button-danger" %>
-
-          <%= link_to t("parent.actions.view_history"), parent_child_history_path(child) %>
-        </footer>
+        <p><%= t("parent.dashboard.card_completed") %></p>
+        <%= button_to t("parent.actions.mark_rewarded"), parent_child_reward_path(child),
+                      method: :post, class: "button-success" %>
       <% end %>
     </article>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
       mark_rewarded: "🎁 Mark Rewarded"
       view_history: "📊 History"
     dashboard:
+      card_completed: "Card completed — awaiting reward"
       open_cards:
         one: "%{count} card ready to reward!"
         other: "%{count} cards ready to reward!"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -53,6 +53,7 @@ it:
       mark_rewarded: "🎁 Segna premiato"
       view_history: "📊 Cronologia"
     dashboard:
+      card_completed: "Scheda completata — in attesa del premio"
       open_cards:
         one: "%{count} scheda pronta per il premio!"
         other: "%{count} schede pronte per il premio!"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -53,6 +53,7 @@ nl:
       mark_rewarded: "🎁 Markeer Beloond"
       view_history: "📊 Geschiedenis"
     dashboard:
+      card_completed: "Kaart vol — beloning uitstaat"
       open_cards:
         one: "%{count} kaart klaar voor beloning!"
         other: "%{count} kaarten klaar voor beloning!"


### PR DESCRIPTION
## Summary

- Always show Give Sticker, Give Penalty, and View History buttons on the parent dashboard
- When a card is complete, append a contextual note and Mark Rewarded below the sticker buttons instead of replacing them
- Add `parent.dashboard.card_completed` i18n key in English, Dutch, and Italian

## Test plan

- [ ] Give a child enough stickers to complete their card — confirm Give Sticker, Give Penalty, View History, the contextual note, and Mark Rewarded all appear
- [ ] Give another sticker — confirm it goes to the new active card (progress counter increments)
- [ ] Click Mark Rewarded — confirm the note and button disappear; sticker buttons remain
- [ ] With a fresh card (not yet completed) — confirm only sticker/penalty/history show, no Mark Rewarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)