### PR TITLE
Update mvpa-css to latest and align flash markup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+      - name: Check translations
+        run: bundle exec i18n-tasks health
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config google-chrome-stable
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config
 
       - name: Checkout code
         uses: actions/checkout@v6.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/eirvandelden/mvpa.css.git
-  revision: bc9d982b8d62c6817928633758fe40d0a561f57e
+  revision: 524c8af99ef7a298aa59d3b5c34a83ba2ceecdd7
   specs:
-    mvpa-css (0.1.0.pre.git.bc9d982)
+    mvpa-css (0.1.0.pre.git.524c8af)
       railties (>= 6.0)
 
 GEM
@@ -117,7 +117,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -139,7 +139,7 @@ GEM
       activesupport (>= 6.1)
     highline (3.1.2)
       reline
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.1.2)
       activesupport (>= 4.0.2)
@@ -166,7 +166,7 @@ GEM
     jbuilder (2.15.0)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.8)
+    json (2.20.0)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -236,7 +236,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -244,9 +244,6 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.4.0)
-      date
-      stringio
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
@@ -295,9 +292,14 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -375,7 +377,6 @@ GEM
       ostruct
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.2.0)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
@@ -479,7 +480,7 @@ CHECKSUMS
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
@@ -493,13 +494,13 @@ CHECKSUMS
   fugit (1.12.2) sha256=643f2bf28db263bd400cbf8e0dd8b76b2c9b94bdb130e12d2394de04d9c20e5e
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
-  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   i18n-tasks (1.1.2) sha256=4dcfba49e52a623f30661cb316cb80d84fbba5cb8c6d88ef5e02545fffa3637a
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.15.0) sha256=fe36cd45b47dd88cb2cbebc3adc4348f041825f580d503578594e8255817f889
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
@@ -513,7 +514,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
-  mvpa-css (0.1.0.pre.git.bc9d982)
+  mvpa-css (0.1.0.pre.git.524c8af)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -532,11 +533,10 @@ CHECKSUMS
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
-  psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
@@ -552,7 +552,8 @@ CHECKSUMS
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
@@ -578,7 +579,6 @@ CHECKSUMS
   sqlite3 (2.9.4-x86_64-linux-musl) sha256=3fc5e865b4be9a85d998203ef8d0c0fdcb92f20acf34a254346ff8a19088efec
   sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
-  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   thruster (0.1.21) sha256=dc67928f36e5894844579a95e45637a5091db7a7ea05468ee8c2c6eb0a3f77cf

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -28,7 +28,7 @@
 
     <main>
       <% if flash.any? %>
-        <output data-mvpa-flashes>
+        <section data-mvpa-flashes>
           <% if flash[:notice] %>
             <aside role="status"><%= flash[:notice] %></aside>
           <% end %>
@@ -36,7 +36,7 @@
           <% if flash[:alert] %>
             <aside role="alert"><%= flash[:alert] %></aside>
           <% end %>
-        </output>
+        </section>
       <% end %>
 
       <%= yield %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Admin - <%= Rails.application.class.module_parent_name %></title>
+    <title><%= t("admin.title") %> - <%= Rails.application.class.module_parent_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="turbo-cache-control" content="no-cache">
     <%= csrf_meta_tags %>
@@ -15,7 +15,7 @@
   <body>
     <header>
       <nav data-controller="nav" data-action="click->nav#click">
-        <h2><%= t("admin.nav.title", default: "Admin") %></h2>
+        <h2><%= t("admin.nav.title") %></h2>
         <ul>
           <li><%= link_to t("admin.nav.dashboard"), admin_root_path, "aria-current": (current_page?(admin_root_path) ? "page" : nil) %></li>
           <li><%= link_to t("admin.nav.users"), admin_users_path, "aria-current": (request.path.start_with?("/admin/users") ? "page" : nil) %></li>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -28,7 +28,7 @@
 
     <main>
       <% if flash.any? %>
-        <section data-mvpa-flashes>
+        <section aria-label="<%= t("flash.notifications") %>" data-mvpa-flashes>
           <% if flash[:notice] %>
             <aside role="status"><%= flash[:notice] %></aside>
           <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -27,12 +27,16 @@
     </header>
 
     <main>
-      <% if flash[:notice] %>
-        <p role="status"><%= flash[:notice] %></p>
-      <% end %>
+      <% if flash.any? %>
+        <output data-mvpa-flashes>
+          <% if flash[:notice] %>
+            <aside role="status"><%= flash[:notice] %></aside>
+          <% end %>
 
-      <% if flash[:alert] %>
-        <p role="alert"><%= flash[:alert] %></p>
+          <% if flash[:alert] %>
+            <aside role="alert"><%= flash[:alert] %></aside>
+          <% end %>
+        </output>
       <% end %>
 
       <%= yield %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <div>
-        <%= f.label :password %>
+        <%= f.label :password, t("sessions.password") %>
         <%= f.password_field :password, required: true %>
       </div>
 

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,9 +1,9 @@
 <% if flash.any? %>
-  <output data-mvpa-flashes>
+  <section data-mvpa-flashes>
     <% flash.each do |type, message| %>
       <aside role="<%= type == 'notice' ? 'status' : 'alert' %>" data-controller="fade-out">
         <%= message %>
       </aside>
     <% end %>
-  </output>
+  </section>
 <% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if flash.any? %>
-  <section data-mvpa-flashes>
+  <section aria-label="<%= t("flash.notifications") %>" data-mvpa-flashes>
     <% flash.each do |type, message| %>
       <aside role="<%= type == 'notice' ? 'status' : 'alert' %>" data-controller="fade-out">
         <%= message %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,9 @@
-<% flash.each do |type, message| %>
-  <div role="<%= type == 'notice' ? 'status' : 'alert' %>" data-controller="fade-out">
-    <%= message %>
-  </div>
+<% if flash.any? %>
+  <output data-mvpa-flashes>
+    <% flash.each do |type, message| %>
+      <aside role="<%= type == 'notice' ? 'status' : 'alert' %>" data-controller="fade-out">
+        <%= message %>
+      </aside>
+    <% end %>
+  </output>
 <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -148,6 +148,9 @@ search:
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'
+ignore_unused:
+  - errors.messages.invalid_content_type
+  - errors.messages.file_size_too_large
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,42 +1,106 @@
 ---
 en:
+  admin:
+    dashboard:
+      index:
+        actions: Actions
+        admin_users: Admin Users
+        created_at: Created
+        edit: Edit
+        email: Email
+        recent_signups: Recent Signups
+        role: Role
+        summary: Summary
+        title: Dashboard
+        total_users: Total Users
+        view: View
+    nav:
+      back_to_site: Back to Site
+      dashboard: Dashboard
+      faultline: Faultline
+      title: Admin
+      users: Users
+    title: Admin
+    users:
+      create:
+        success: User created successfully
+      destroy:
+        cannot_delete_self: You cannot delete yourself
+        success: User deleted successfully
+      edit:
+        submit: Update User
+        title: Edit User
+      form:
+        avatar: Avatar
+        cancel: Cancel
+        current_avatar: Current avatar
+        email: Email
+        locale: Language
+        name: Name
+        password: Password
+        password_confirmation: Confirm Password
+        role: Role
+      index:
+        actions: Actions
+        confirm_delete: Are you sure you want to delete this user?
+        created_at: Created
+        delete: Delete
+        edit: Edit
+        email: Email
+        new_user: New User
+        role: Role
+        title: User Management
+        view: View
+      new:
+        submit: Create User
+        title: New User
+      show:
+        active_sessions: Active Sessions
+        back: Back
+        created_at: Created
+        edit: Edit
+        email: Email
+        role: Role
+        title: User Details
+      update:
+        success: User updated successfully
   app:
-    title: "Sticker App"
+    title: Sticker App
   child:
     dashboard:
       completed:
         one: "You've completed 1 card so far 🎁"
         other: "You've completed %{count} cards so far 🎁"
       earned: You've earned %{current} out of %{total} stickers.
+      gave_you: gave you
       new_stickers:
         one: "🎉 You got 1 new sticker since last time!"
         other: "🎉 You got %{count} new stickers since last time!"
       no_card: You don't have a sticker card yet.
-      profile_link: "My Profile"
-      someone: "Someone"
-      gave_you: "gave you"
+      profile_link: My Profile
+      someone: Someone
       title: Your Sticker Card
   common:
-    logout: "Logout 🐿️"
     back: "← Back"
-  locale_names:
-    en: "English"
-    nl: "Dutch"
-    it: "Italian"
+    logout: "Logout 🐿️"
   errors:
-    authentication_required: "Please log in"
-    admin_required: "Admin access required"
-    parent_required: "Parent access required"
-    child_required: "Child access required"
-    child_profile_required: "Child profile not found"
+    admin_required: Admin access required
+    authentication_required: Please log in
+    child_profile_required: Child profile not found
+    child_required: Child access required
     messages:
-      invalid_content_type: "must be PNG, JPEG, GIF, or WebP"
-      file_size_too_large: "must be smaller than 5 MB"
+      file_size_too_large: must be smaller than 5 MB
+      invalid_content_type: must be PNG, JPEG, GIF, or WebP
+    parent_required: Parent access required
+    template:
+      header:
+        one: 1 error prevented this record from being saved
+        other: "%{count} errors prevented this record from being saved"
   flash:
     notifications: Notifications
     parent:
       child_profiles:
-        updated: "Settings saved"
+        updated: Settings saved
       penalties:
         created: Penalty added ❌
       rewards:
@@ -44,169 +108,108 @@ en:
         success: "🎁 Reward marked as given!"
       stickers:
         created: Sticker added ✅
-    sessions:
-      invalid: Invalid email or password
-      logged_out: "Logged out 🐿️"
-      unauthorized: "Invalid email or password."
-      too_many_requests: "Too many login attempts. Please try again later."
     preferences:
-      updated: "Preferences updated successfully"
+      updated: Preferences updated successfully
+    sessions:
+      logged_out: "Logged out 🐿️"
+      too_many_requests: Too many login attempts. Please try again later.
+      unauthorized: Invalid email or password.
+  locale_names:
+    en: English
+    it: Italian
+    nl: Dutch
+  navigation:
+    admin: Admin
+    preferences: Preferences
   parent:
-    children:
-      edit:
-        title: "Edit Child"
-        name_label: "Name"
-        save: "Save"
-        cancel: "Cancel"
-      update:
-        success: "Child updated successfully"
-      index:
-        edit_name: "Edit name"
-        edit_avatar: "Edit avatar"
-    children_avatar:
-      edit:
-        title: "Edit Avatar"
-        current_avatar: "Current avatar"
-        upload_label: "Choose a new avatar"
-        save: "Save"
-        cancel: "Cancel"
-      update:
-        success: "Avatar updated successfully"
     actions:
-      give_sticker: "🎉 Give Sticker"
       give_penalty: "❌ Give Penalty"
+      give_sticker: "🎉 Give Sticker"
       mark_rewarded: "🎁 Mark Rewarded"
       view_history: "📊 History"
+    child_profile:
+      edit:
+        cancel: Cancel
+        save: Save
+        sticker_goal_label: Sticker goal
+        title: Child Settings
+    children:
+      edit:
+        cancel: Cancel
+        name_label: Name
+        save: Save
+        title: Edit Child
+      index:
+        edit_avatar: Edit avatar
+        edit_name: Edit name
+      update:
+        success: Child updated successfully
+    children_avatar:
+      edit:
+        cancel: Cancel
+        current_avatar: Current avatar
+        save: Save
+        title: Edit Avatar
+        upload_label: Choose a new avatar
+      update:
+        success: Avatar updated successfully
     dashboard:
-      card_completed: "Card completed — awaiting reward"
+      card_completed: Card completed — awaiting reward
       open_cards:
         one: "%{count} card ready to reward!"
         other: "%{count} cards ready to reward!"
       progress: 'Progress: %{current} / %{total} stickers'
       title: Parent Dashboard
-    child_profile:
-      edit:
-        title: "Child Settings"
-        sticker_goal_label: "Sticker goal"
-        save: "Save"
-        cancel: "Cancel"
     history:
-      title: "Sticker History"
       back: "← Back"
-      stickers:
-        one: "%{count} sticker"
-        other: "%{count} stickers"
+      no_stickers: No stickers yet
       penalties:
         one: "%{count} penalty"
         other: "%{count} penalties"
-      no_stickers: "No stickers yet"
+      stickers:
+        one: "%{count} sticker"
+        other: "%{count} stickers"
+      title: Sticker History
+  preferences:
+    account_label: Account
+    color_scheme:
+      dark: Dark
+      light: Light
+      system: System
+    dark_theme:
+      black: Black
+      selenized_dark: Selenized Dark
+    email: Email
+    language_label: Language
+    light_theme:
+      selenized_light: Selenized Light
+      white: White
+    password: Password
+    password_confirmation: Confirm Password
+    password_placeholder: Leave blank to keep current password
+    save: Save Preferences
+    theme_label: Theme
+    title: Preferences
   sessions:
     email: Email
     login_button: Login
     login_title: Login
     password: Password
-  preferences:
-    title: "Preferences"
-    account_label: "Account"
-    email: "Email"
-    password: "Password"
-    password_placeholder: "Leave blank to keep current password"
-    password_confirmation: "Confirm Password"
-    language_label: "Language"
-    theme_label: "Theme"
-    color_scheme:
-      system: "System"
-      light: "Light"
-      dark: "Dark"
-    light_theme:
-      white: "White"
-      selenized_light: "Selenized Light"
-    dark_theme:
-      black: "Black"
-      selenized_dark: "Selenized Dark"
-    save: "Save Preferences"
-  admin:
-    title: "Admin"
-    nav:
-      dashboard: "Dashboard"
-      users: "Users"
-      faultline: "Faultline"
-      back_to_site: "Back to Site"
-    dashboard:
-      index:
-        title: "Dashboard"
-        summary: "Summary"
-        total_users: "Total Users"
-        admin_users: "Admin Users"
-        recent_signups: "Recent Signups"
-        email: "Email"
-        role: "Role"
-        created_at: "Created"
-        actions: "Actions"
-        view: "View"
-        edit: "Edit"
-    users:
-      index:
-        title: "User Management"
-        new_user: "New User"
-        email: "Email"
-        role: "Role"
-        created_at: "Created"
-        actions: "Actions"
-        view: "View"
-        edit: "Edit"
-        delete: "Delete"
-        confirm_delete: "Are you sure you want to delete this user?"
-      show:
-        title: "User Details"
-        email: "Email"
-        role: "Role"
-        created_at: "Created"
-        active_sessions: "Active Sessions"
-        edit: "Edit"
-        back: "Back"
-      new:
-        title: "New User"
-        submit: "Create User"
-      form:
-        email: "Email"
-        name: "Name"
-        role: "Role"
-        password: "Password"
-        password_confirmation: "Confirm Password"
-        locale: "Language"
-        avatar: "Avatar"
-        current_avatar: "Current avatar"
-        cancel: "Cancel"
-      create:
-        success: "User created successfully"
-      edit:
-        title: "Edit User"
-        submit: "Update User"
-      update:
-        success: "User updated successfully"
-      destroy:
-        success: "User deleted successfully"
-        cannot_delete_self: "You cannot delete yourself"
-  navigation:
-    admin: "Admin"
-    preferences: "Preferences"
   users:
     profiles:
-      show:
-        title: "My Profile"
-        name: "Name"
-        email: "Email"
-        avatar: "Avatar"
-        edit: "Edit profile"
       edit:
-        title: "Edit Profile"
-        name_label: "Name"
-        avatar_label: "Avatar"
-        current_avatar: "Current avatar"
-        email_label: "Email"
-        password_label: "Change password"
-        save: "Save"
-        cancel: "Cancel"
+        avatar_label: Avatar
+        cancel: Cancel
+        current_avatar: Current avatar
+        email_label: Email
+        name_label: Name
+        password_label: Change password
+        save: Save
+        title: Edit Profile
+      show:
+        edit: Edit profile
+        email: Email
+        name: Name
+        title: My Profile
       update:
-        success: "Profile updated successfully"
+        success: Profile updated successfully

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
       invalid_content_type: "must be PNG, JPEG, GIF, or WebP"
       file_size_too_large: "must be smaller than 5 MB"
   flash:
+    notifications: Notifications
     parent:
       child_profiles:
         updated: "Settings saved"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -33,6 +33,7 @@ it:
       invalid_content_type: "deve essere PNG, JPEG, GIF o WebP"
       file_size_too_large: "deve essere inferiore a 5 MB"
   flash:
+    notifications: Notifiche
     parent:
       child_profiles:
         updated: "Impostazioni salvate"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,212 +1,215 @@
 ---
 it:
+  admin:
+    dashboard:
+      index:
+        actions: Azioni
+        admin_users: Utenti Admin
+        created_at: Creato
+        edit: Modifica
+        email: Email
+        recent_signups: Iscrizioni Recenti
+        role: Ruolo
+        summary: Riepilogo
+        title: Dashboard
+        total_users: Utenti Totali
+        view: Visualizza
+    nav:
+      back_to_site: Torna al sito
+      dashboard: Dashboard
+      faultline: Faultline
+      title: Admin
+      users: Utenti
+    title: Admin
+    users:
+      create:
+        success: Utente creato con successo
+      destroy:
+        cannot_delete_self: Non puoi eliminare te stesso
+        success: Utente eliminato con successo
+      edit:
+        submit: Aggiorna Utente
+        title: Modifica Utente
+      form:
+        avatar: Avatar
+        cancel: Annulla
+        current_avatar: Avatar attuale
+        email: Email
+        locale: Lingua
+        name: Nome
+        password: Password
+        password_confirmation: Conferma Password
+        role: Ruolo
+      index:
+        actions: Azioni
+        confirm_delete: Sei sicuro di voler eliminare questo utente?
+        created_at: Creato
+        delete: Elimina
+        edit: Modifica
+        email: Email
+        new_user: Nuovo Utente
+        role: Ruolo
+        title: Gestione Utenti
+        view: Visualizza
+      new:
+        submit: Crea Utente
+        title: Nuovo Utente
+      show:
+        active_sessions: Sessioni Attive
+        back: Indietro
+        created_at: Creato
+        edit: Modifica
+        email: Email
+        role: Ruolo
+        title: Dettagli Utente
+      update:
+        success: Utente aggiornato con successo
   app:
-    title: "Sticker App"
+    title: Sticker App
   child:
     dashboard:
       completed:
         one: "Hai completato 1 scheda finora 🎁"
         other: "Hai completato %{count} schede finora 🎁"
-      earned: "Hai guadagnato %{current} su %{total} adesivi."
+      earned: Hai guadagnato %{current} su %{total} adesivi.
+      gave_you: ti ha dato
       new_stickers:
         one: "🎉 Hai ricevuto 1 nuovo adesivo dall'ultima volta!"
         other: "🎉 Hai ricevuto %{count} nuovi adesivi dall'ultima volta!"
-      no_card: "Non hai ancora una scheda adesivi."
-      profile_link: "Il mio profilo"
-      someone: "Qualcuno"
-      gave_you: "ti ha dato"
-      title: "La tua scheda adesivi"
+      no_card: Non hai ancora una scheda adesivi.
+      profile_link: Il mio profilo
+      someone: Qualcuno
+      title: La tua scheda adesivi
   common:
-    logout: "Esci 🐿️"
     back: "← Indietro"
-  locale_names:
-    en: "Inglese"
-    nl: "Olandese"
-    it: "Italiano"
+    logout: "Esci 🐿️"
   errors:
-    authentication_required: "Effettua il login"
-    admin_required: "Accesso admin richiesto"
-    parent_required: "Accesso genitore richiesto"
-    child_required: "Accesso bambino richiesto"
-    child_profile_required: "Profilo bambino non trovato"
+    admin_required: Accesso admin richiesto
+    authentication_required: Effettua il login
+    child_profile_required: Profilo bambino non trovato
+    child_required: Accesso bambino richiesto
     messages:
-      invalid_content_type: "deve essere PNG, JPEG, GIF o WebP"
-      file_size_too_large: "deve essere inferiore a 5 MB"
+      file_size_too_large: deve essere inferiore a 5 MB
+      invalid_content_type: deve essere PNG, JPEG, GIF o WebP
+    parent_required: Accesso genitore richiesto
+    template:
+      header:
+        one: 1 errore ha impedito il salvataggio di questo record
+        other: "%{count} errori hanno impedito il salvataggio di questo record"
   flash:
     notifications: Notifiche
     parent:
       child_profiles:
-        updated: "Impostazioni salvate"
+        updated: Impostazioni salvate
       penalties:
-        created: "Penalita aggiunta ❌"
+        created: Penalita aggiunta ❌
       rewards:
-        failure: "La scheda non e ancora completa."
+        failure: La scheda non e ancora completa.
         success: "🎁 Premio segnato come consegnato!"
       stickers:
-        created: "Adesivo aggiunto ✅"
-    sessions:
-      invalid: "Email o password non validi"
-      logged_out: "Disconnesso 🐿️"
-      unauthorized: "Email o password non validi."
-      too_many_requests: "Troppi tentativi di accesso. Riprova più tardi."
+        created: Adesivo aggiunto ✅
     preferences:
-      updated: "Preferenze aggiornate con successo"
+      updated: Preferenze aggiornate con successo
+    sessions:
+      logged_out: "Disconnesso 🐿️"
+      too_many_requests: Troppi tentativi di accesso. Riprova più tardi.
+      unauthorized: Email o password non validi.
+  locale_names:
+    en: Inglese
+    it: Italiano
+    nl: Olandese
+  navigation:
+    admin: Admin
+    preferences: Preferenze
   parent:
-    children:
-      edit:
-        title: "Modifica bambino"
-        name_label: "Nome"
-        save: "Salva"
-        cancel: "Annulla"
-      update:
-        success: "Bambino aggiornato con successo"
-      index:
-        edit_name: "Modifica nome"
-        edit_avatar: "Modifica avatar"
-    children_avatar:
-      edit:
-        title: "Modifica avatar"
-        current_avatar: "Avatar attuale"
-        upload_label: "Scegli un nuovo avatar"
-        save: "Salva"
-        cancel: "Annulla"
-      update:
-        success: "Avatar aggiornato con successo"
     actions:
-      give_sticker: "🎉 Dai adesivo"
       give_penalty: "❌ Dai penalita"
+      give_sticker: "🎉 Dai adesivo"
       mark_rewarded: "🎁 Segna premiato"
       view_history: "📊 Cronologia"
+    child_profile:
+      edit:
+        cancel: Annulla
+        save: Salva
+        sticker_goal_label: Obiettivo adesivi
+        title: Impostazioni bambino
+    children:
+      edit:
+        cancel: Annulla
+        name_label: Nome
+        save: Salva
+        title: Modifica bambino
+      index:
+        edit_avatar: Modifica avatar
+        edit_name: Modifica nome
+      update:
+        success: Bambino aggiornato con successo
+    children_avatar:
+      edit:
+        cancel: Annulla
+        current_avatar: Avatar attuale
+        save: Salva
+        title: Modifica avatar
+        upload_label: Scegli un nuovo avatar
+      update:
+        success: Avatar aggiornato con successo
     dashboard:
-      card_completed: "Scheda completata — in attesa del premio"
+      card_completed: Scheda completata — in attesa del premio
       open_cards:
         one: "%{count} scheda pronta per il premio!"
         other: "%{count} schede pronte per il premio!"
-      progress: "Progresso: %{current} / %{total} adesivi"
-      title: "Dashboard Genitore"
-    child_profile:
-      edit:
-        title: "Impostazioni bambino"
-        sticker_goal_label: "Obiettivo adesivi"
-        save: "Salva"
-        cancel: "Annulla"
+      progress: 'Progresso: %{current} / %{total} adesivi'
+      title: Dashboard Genitore
     history:
-      title: "Cronologia Adesivi"
       back: "← Indietro"
-      stickers:
-        one: "%{count} adesivo"
-        other: "%{count} adesivi"
+      no_stickers: Ancora nessun adesivo
       penalties:
         one: "%{count} penalita"
         other: "%{count} penalita"
-      no_stickers: "Ancora nessun adesivo"
-  sessions:
-    email: "Email"
-    login_button: "Accedi"
-    login_title: "Accedi"
-    password: "Password"
+      stickers:
+        one: "%{count} adesivo"
+        other: "%{count} adesivi"
+      title: Cronologia Adesivi
   preferences:
-    title: "Preferenze"
-    account_label: "Account"
-    email: "Email"
-    password: "Password"
-    password_placeholder: "Lascia vuoto per mantenere la password attuale"
-    password_confirmation: "Conferma Password"
-    language_label: "Lingua"
-    theme_label: "Tema"
+    account_label: Account
     color_scheme:
-      system: "Sistema"
-      light: "Chiaro"
-      dark: "Scuro"
-    light_theme:
-      white: "Bianco"
-      selenized_light: "Selenized Chiaro"
+      dark: Scuro
+      light: Chiaro
+      system: Sistema
     dark_theme:
-      black: "Nero"
-      selenized_dark: "Selenized Scuro"
-    save: "Salva Preferenze"
-  admin:
-    title: "Admin"
-    nav:
-      dashboard: "Dashboard"
-      users: "Utenti"
-      faultline: "Faultline"
-      back_to_site: "Torna al sito"
-    dashboard:
-      index:
-        title: "Dashboard"
-        summary: "Riepilogo"
-        total_users: "Utenti Totali"
-        admin_users: "Utenti Admin"
-        recent_signups: "Iscrizioni Recenti"
-        email: "Email"
-        role: "Ruolo"
-        created_at: "Creato"
-        actions: "Azioni"
-        view: "Visualizza"
-        edit: "Modifica"
-    users:
-      index:
-        title: "Gestione Utenti"
-        new_user: "Nuovo Utente"
-        email: "Email"
-        role: "Ruolo"
-        created_at: "Creato"
-        actions: "Azioni"
-        view: "Visualizza"
-        edit: "Modifica"
-        delete: "Elimina"
-        confirm_delete: "Sei sicuro di voler eliminare questo utente?"
-      show:
-        title: "Dettagli Utente"
-        email: "Email"
-        role: "Ruolo"
-        created_at: "Creato"
-        active_sessions: "Sessioni Attive"
-        edit: "Modifica"
-        back: "Indietro"
-      new:
-        title: "Nuovo Utente"
-        submit: "Crea Utente"
-      form:
-        email: "Email"
-        name: "Nome"
-        role: "Ruolo"
-        password: "Password"
-        password_confirmation: "Conferma Password"
-        locale: "Lingua"
-        avatar: "Avatar"
-        current_avatar: "Avatar attuale"
-        cancel: "Annulla"
-      create:
-        success: "Utente creato con successo"
-      edit:
-        title: "Modifica Utente"
-        submit: "Aggiorna Utente"
-      update:
-        success: "Utente aggiornato con successo"
-      destroy:
-        success: "Utente eliminato con successo"
-        cannot_delete_self: "Non puoi eliminare te stesso"
-  navigation:
-    admin: "Admin"
-    preferences: "Preferenze"
+      black: Nero
+      selenized_dark: Selenized Scuro
+    email: Email
+    language_label: Lingua
+    light_theme:
+      selenized_light: Selenized Chiaro
+      white: Bianco
+    password: Password
+    password_confirmation: Conferma Password
+    password_placeholder: Lascia vuoto per mantenere la password attuale
+    save: Salva Preferenze
+    theme_label: Tema
+    title: Preferenze
+  sessions:
+    email: Email
+    login_button: Accedi
+    login_title: Accedi
+    password: Password
   users:
     profiles:
-      show:
-        title: "Il mio profilo"
-        name: "Nome"
-        email: "Email"
-        avatar: "Avatar"
-        edit: "Modifica profilo"
       edit:
-        title: "Modifica profilo"
-        name_label: "Nome"
-        avatar_label: "Avatar"
-        current_avatar: "Avatar attuale"
-        email_label: "Email"
-        password_label: "Cambia password"
-        save: "Salva"
-        cancel: "Annulla"
+        avatar_label: Avatar
+        cancel: Annulla
+        current_avatar: Avatar attuale
+        email_label: Email
+        name_label: Nome
+        password_label: Cambia password
+        save: Salva
+        title: Modifica profilo
+      show:
+        edit: Modifica profilo
+        email: Email
+        name: Nome
+        title: Il mio profilo
       update:
-        success: "Profilo aggiornato con successo"
+        success: Profilo aggiornato con successo

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -33,6 +33,7 @@ nl:
       invalid_content_type: "moet PNG, JPEG, GIF of WebP zijn"
       file_size_too_large: "moet kleiner zijn dan 5 MB"
   flash:
+    notifications: Meldingen
     parent:
       child_profiles:
         updated: "Instellingen opgeslagen"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,42 +1,106 @@
 ---
 nl:
+  admin:
+    dashboard:
+      index:
+        actions: Acties
+        admin_users: Admin-gebruikers
+        created_at: Aangemaakt
+        edit: Bewerken
+        email: E-mail
+        recent_signups: Recente aanmeldingen
+        role: Rol
+        summary: Overzicht
+        title: Dashboard
+        total_users: Totaal gebruikers
+        view: Bekijken
+    nav:
+      back_to_site: Terug naar site
+      dashboard: Dashboard
+      faultline: Faultline
+      title: Beheer
+      users: Gebruikers
+    title: Beheer
+    users:
+      create:
+        success: Gebruiker succesvol aangemaakt
+      destroy:
+        cannot_delete_self: Je kunt jezelf niet verwijderen
+        success: Gebruiker succesvol verwijderd
+      edit:
+        submit: Gebruiker bijwerken
+        title: Gebruiker bewerken
+      form:
+        avatar: Avatar
+        cancel: Annuleren
+        current_avatar: Huidige avatar
+        email: E-mail
+        locale: Taal
+        name: Naam
+        password: Wachtwoord
+        password_confirmation: Bevestig wachtwoord
+        role: Rol
+      index:
+        actions: Acties
+        confirm_delete: Weet je zeker dat je deze gebruiker wilt verwijderen?
+        created_at: Aangemaakt
+        delete: Verwijderen
+        edit: Bewerken
+        email: E-mail
+        new_user: Nieuwe gebruiker
+        role: Rol
+        title: Gebruikersbeheer
+        view: Bekijken
+      new:
+        submit: Gebruiker aanmaken
+        title: Nieuwe gebruiker
+      show:
+        active_sessions: Actieve sessies
+        back: Terug
+        created_at: Aangemaakt
+        edit: Bewerken
+        email: E-mail
+        role: Rol
+        title: Gebruikersdetails
+      update:
+        success: Gebruiker succesvol bijgewerkt
   app:
-    title: "Sticker App"
+    title: Sticker App
   child:
     dashboard:
       completed:
         one: "Je hebt 1 kaart vol 🎁"
         other: "Je hebt %{count} kaarten vol 🎁"
       earned: Je hebt %{current} van %{total} stickers verdient.
+      gave_you: gaf je
       new_stickers:
         one: "🎉 Je hebt 1 nieuwe sticker verdiend!"
         other: "🎉 Je hebt %{count} nieuwe stickers verdiend!"
       no_card: Je hebt nog geen sticker kaart.
-      profile_link: "Mijn profiel"
-      someone: "Iemand"
-      gave_you: "gaf je"
+      profile_link: Mijn profiel
+      someone: Iemand
       title: Jouw sticker kaart
   common:
-    logout: "Uitloggen 🐿️"
     back: "← Terug"
-  locale_names:
-    en: "Engels"
-    nl: "Nederlands"
-    it: "Italiaans"
+    logout: "Uitloggen 🐿️"
   errors:
-    authentication_required: "Gelieve in te loggen"
-    admin_required: "Admin toegang vereist"
-    parent_required: "Parent toegang vereist"
-    child_required: "Child toegang vereist"
-    child_profile_required: "Kind profiel niet gevonden"
+    admin_required: Admin toegang vereist
+    authentication_required: Gelieve in te loggen
+    child_profile_required: Kind profiel niet gevonden
+    child_required: Child toegang vereist
     messages:
-      invalid_content_type: "moet PNG, JPEG, GIF of WebP zijn"
-      file_size_too_large: "moet kleiner zijn dan 5 MB"
+      file_size_too_large: moet kleiner zijn dan 5 MB
+      invalid_content_type: moet PNG, JPEG, GIF of WebP zijn
+    parent_required: Parent toegang vereist
+    template:
+      header:
+        one: 1 fout verhinderde dat dit record werd opgeslagen
+        other: "%{count} fouten verhinderden dat dit record werd opgeslagen"
   flash:
     notifications: Meldingen
     parent:
       child_profiles:
-        updated: "Instellingen opgeslagen"
+        updated: Instellingen opgeslagen
       penalties:
         created: Straf toegevoegd ❌
       rewards:
@@ -44,169 +108,108 @@ nl:
         success: "🎁 Cadeautje is gegeven!"
       stickers:
         created: Sticker toegevoegd ✅
-    sessions:
-      invalid: Ongeldig e-mail of wachtwoord
-      logged_out: "Uitgelogd 🐿️"
-      unauthorized: "Ongeldig e-mailadres of wachtwoord."
-      too_many_requests: "Te veel inlogpogingen. Probeer het later opnieuw."
     preferences:
-      updated: "Voorkeuren bijgewerkt"
+      updated: Voorkeuren bijgewerkt
+    sessions:
+      logged_out: "Uitgelogd 🐿️"
+      too_many_requests: Te veel inlogpogingen. Probeer het later opnieuw.
+      unauthorized: Ongeldig e-mailadres of wachtwoord.
+  locale_names:
+    en: Engels
+    it: Italiaans
+    nl: Nederlands
+  navigation:
+    admin: Beheer
+    preferences: Voorkeuren
   parent:
-    children:
-      edit:
-        title: "Kind bewerken"
-        name_label: "Naam"
-        save: "Opslaan"
-        cancel: "Annuleren"
-      update:
-        success: "Kind succesvol bijgewerkt"
-      index:
-        edit_name: "Naam bewerken"
-        edit_avatar: "Avatar bewerken"
-    children_avatar:
-      edit:
-        title: "Avatar bewerken"
-        current_avatar: "Huidige avatar"
-        upload_label: "Kies een nieuwe avatar"
-        save: "Opslaan"
-        cancel: "Annuleren"
-      update:
-        success: "Avatar succesvol bijgewerkt"
     actions:
-      give_sticker: "🎉 Geef Sticker"
       give_penalty: "❌ Geef Straf"
+      give_sticker: "🎉 Geef Sticker"
       mark_rewarded: "🎁 Markeer Beloond"
       view_history: "📊 Geschiedenis"
+    child_profile:
+      edit:
+        cancel: Annuleren
+        save: Opslaan
+        sticker_goal_label: Stickerdoel
+        title: Kind-instellingen
+    children:
+      edit:
+        cancel: Annuleren
+        name_label: Naam
+        save: Opslaan
+        title: Kind bewerken
+      index:
+        edit_avatar: Avatar bewerken
+        edit_name: Naam bewerken
+      update:
+        success: Kind succesvol bijgewerkt
+    children_avatar:
+      edit:
+        cancel: Annuleren
+        current_avatar: Huidige avatar
+        save: Opslaan
+        title: Avatar bewerken
+        upload_label: Kies een nieuwe avatar
+      update:
+        success: Avatar succesvol bijgewerkt
     dashboard:
-      card_completed: "Kaart vol — beloning uitstaat"
+      card_completed: Kaart vol — beloning uitstaat
       open_cards:
         one: "%{count} kaart klaar voor beloning!"
         other: "%{count} kaarten klaar voor beloning!"
       progress: 'Voortgang: %{current} / %{total} stickers'
       title: Ouder Dashboard
-    child_profile:
-      edit:
-        title: "Kind-instellingen"
-        sticker_goal_label: "Stickerdoel"
-        save: "Opslaan"
-        cancel: "Annuleren"
     history:
-      title: "Sticker Geschiedenis"
       back: "← Terug"
-      stickers:
-        one: "%{count} sticker"
-        other: "%{count} stickers"
+      no_stickers: Nog geen stickers
       penalties:
         one: "%{count} straf"
         other: "%{count} straffen"
-      no_stickers: "Nog geen stickers"
+      stickers:
+        one: "%{count} sticker"
+        other: "%{count} stickers"
+      title: Sticker Geschiedenis
+  preferences:
+    account_label: Account
+    color_scheme:
+      dark: Donker
+      light: Licht
+      system: Systeem
+    dark_theme:
+      black: Zwart
+      selenized_dark: Selenized Donker
+    email: E-mail
+    language_label: Taal
+    light_theme:
+      selenized_light: Selenized Licht
+      white: Wit
+    password: Wachtwoord
+    password_confirmation: Bevestig wachtwoord
+    password_placeholder: Laat leeg om huidig wachtwoord te bewaren
+    save: Voorkeuren Opslaan
+    theme_label: Thema
+    title: Voorkeuren
   sessions:
     email: E-mail
     login_button: Log in
     login_title: Log in
     password: Wachtwoord
-  preferences:
-    title: "Voorkeuren"
-    account_label: "Account"
-    email: "E-mail"
-    password: "Wachtwoord"
-    password_placeholder: "Laat leeg om huidig wachtwoord te bewaren"
-    password_confirmation: "Bevestig wachtwoord"
-    language_label: "Taal"
-    theme_label: "Thema"
-    color_scheme:
-      system: "Systeem"
-      light: "Licht"
-      dark: "Donker"
-    light_theme:
-      white: "Wit"
-      selenized_light: "Selenized Licht"
-    dark_theme:
-      black: "Zwart"
-      selenized_dark: "Selenized Donker"
-    save: "Voorkeuren Opslaan"
-  admin:
-    title: "Beheer"
-    nav:
-      dashboard: "Dashboard"
-      users: "Gebruikers"
-      faultline: "Faultline"
-      back_to_site: "Terug naar site"
-    dashboard:
-      index:
-        title: "Dashboard"
-        summary: "Overzicht"
-        total_users: "Totaal gebruikers"
-        admin_users: "Admin-gebruikers"
-        recent_signups: "Recente aanmeldingen"
-        email: "E-mail"
-        role: "Rol"
-        created_at: "Aangemaakt"
-        actions: "Acties"
-        view: "Bekijken"
-        edit: "Bewerken"
-    users:
-      index:
-        title: "Gebruikersbeheer"
-        new_user: "Nieuwe gebruiker"
-        email: "E-mail"
-        role: "Rol"
-        created_at: "Aangemaakt"
-        actions: "Acties"
-        view: "Bekijken"
-        edit: "Bewerken"
-        delete: "Verwijderen"
-        confirm_delete: "Weet je zeker dat je deze gebruiker wilt verwijderen?"
-      show:
-        title: "Gebruikersdetails"
-        email: "E-mail"
-        role: "Rol"
-        created_at: "Aangemaakt"
-        active_sessions: "Actieve sessies"
-        edit: "Bewerken"
-        back: "Terug"
-      new:
-        title: "Nieuwe gebruiker"
-        submit: "Gebruiker aanmaken"
-      form:
-        email: "E-mail"
-        name: "Naam"
-        role: "Rol"
-        password: "Wachtwoord"
-        password_confirmation: "Bevestig wachtwoord"
-        locale: "Taal"
-        avatar: "Avatar"
-        current_avatar: "Huidige avatar"
-        cancel: "Annuleren"
-      create:
-        success: "Gebruiker succesvol aangemaakt"
-      edit:
-        title: "Gebruiker bewerken"
-        submit: "Gebruiker bijwerken"
-      update:
-        success: "Gebruiker succesvol bijgewerkt"
-      destroy:
-        success: "Gebruiker succesvol verwijderd"
-        cannot_delete_self: "Je kunt jezelf niet verwijderen"
-  navigation:
-    admin: "Beheer"
-    preferences: "Voorkeuren"
   users:
     profiles:
-      show:
-        title: "Mijn profiel"
-        name: "Naam"
-        email: "E-mail"
-        avatar: "Avatar"
-        edit: "Profiel bewerken"
       edit:
-        title: "Profiel bewerken"
-        name_label: "Naam"
-        avatar_label: "Avatar"
-        current_avatar: "Huidige avatar"
-        email_label: "E-mail"
-        password_label: "Wachtwoord wijzigen"
-        save: "Opslaan"
-        cancel: "Annuleren"
+        avatar_label: Avatar
+        cancel: Annuleren
+        current_avatar: Huidige avatar
+        email_label: E-mail
+        name_label: Naam
+        password_label: Wachtwoord wijzigen
+        save: Opslaan
+        title: Profiel bewerken
+      show:
+        edit: Profiel bewerken
+        email: E-mail
+        name: Naam
+        title: Mijn profiel
       update:
-        success: "Profiel succesvol bijgewerkt"
+        success: Profiel succesvol bijgewerkt

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -3,9 +3,6 @@
 require "test_helper"
 
 class I18nTest < ActiveSupport::TestCase
-  # i18n-tasks gem removed due to Ruby 4.0 compatibility issues
-  # Tests skipped - consider re-enabling when gem is updated or use manual verification
-
   def test_locales_are_present
     assert File.exist?(Rails.root.join("config/locales/en.yml"))
     assert File.exist?(Rails.root.join("config/locales/nl.yml"))
@@ -20,5 +17,9 @@ class I18nTest < ActiveSupport::TestCase
     assert_includes I18n.available_locales, :en
     assert_includes I18n.available_locales, :nl
     assert_includes I18n.available_locales, :it
+  end
+
+  def test_i18n_tasks_health
+    assert system("bundle", "exec", "i18n-tasks", "health")
   end
 end

--- a/test/integration/flash_test.rb
+++ b/test/integration/flash_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class FlashTest < ActionDispatch::IntegrationTest
+  test "application flash container is labelled" do
+    sign_in_as(users(:user))
+
+    patch preferences_path, params: { user: { locale: "en" } }
+    follow_redirect!
+
+    assert_select %(section[data-mvpa-flashes][aria-label="#{I18n.t("flash.notifications")}"])
+  end
+
+  test "admin flash container is labelled" do
+    admin = users(:admin)
+    sign_in_as(admin)
+
+    delete admin_user_path(admin)
+    follow_redirect!
+
+    assert_select %(section[data-mvpa-flashes][aria-label="#{I18n.t("flash.notifications")}"])
+  end
+end


### PR DESCRIPTION
## Summary

- Bump `mvpa-css` gem from `bc9d982` to `524c8af` (latest from `eirvandelden/mvpa.css`)
- The new version introduces a toast-notification pattern: `[data-mvpa-flashes] > aside[role]`
- Update both flash partials to match: replace `<div>`/`<p>` wrappers with `<output data-mvpa-flashes>` containing `<aside role="status/alert">` elements
- Only render the flash container when flash messages are present

## Test plan

- [ ] 112 tests pass locally (`bundle exec rails test`)
- [ ] Login page renders correctly (typography, button styles, spacing)
- [ ] Flash messages appear styled when triggered (notice = green, alert = red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)