### PR TITLE
Tune SQLite PRAGMAs to reduce production lock contention

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,10 +4,20 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem "sqlite3"
 #
+default_pragmas: &default_pragmas
+  journal_mode: wal
+  synchronous: normal
+  temp_store: memory
+  mmap_size: 134217728
+  cache_size: -20000
+  busy_timeout: 5000
+  wal_autocheckpoint: 10000
+
 default: &default
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  pragmas: *default_pragmas
 
 development:
   <<: *default


### PR DESCRIPTION
## Summary
- Add explicit `temp_store`, `cache_size`, `wal_autocheckpoint`, and `busy_timeout` PRAGMAs to `config/database.yml`, applied via a shared anchor to development, test, and all production connections (primary/cache/queue/cable).
- Rails 8.1 already defaults `journal_mode: wal`, `synchronous: normal`, and `mmap_size`; those are now made explicit alongside the new settings for clarity.
- Based on recommendations for avoiding SQLite lock contention under concurrent Rails access.

## Test plan
- [x] Verified pragmas apply on a live connection (`journal_mode=wal`, `synchronous=1`, `temp_store=2`, `cache_size=-20000`, `wal_autocheckpoint=10000`, `busy_timeout=5000`)
- [x] Full test suite passes (115 runs, 0 failures)