### PR TITLE
Add sliding 20-year session cookie renewal

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,6 +1,8 @@
 module Authentication
   extend ActiveSupport::Concern
 
+  SESSION_COOKIE_LIFETIME = 20.years
+
   included do
     before_action :resume_session
     before_action :set_locale
@@ -18,7 +20,18 @@ module Authentication
     if session_token = cookies.signed[:session_token]
       Current.session = Session.find_by(token: session_token)
       Current.user = Current.session&.user
+      renew_session_cookie(session_token) if Current.user
     end
+  end
+
+  def renew_session_cookie(session_token)
+    cookies.signed[:session_token] = {
+      value: session_token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax,
+      expires: SESSION_COOKIE_LIFETIME.from_now
+    }
   end
 
   def start_new_session_for(user)
@@ -29,15 +42,13 @@ module Authentication
     Current.session = session_record
     Current.user = user
 
-    cookie_options = {
+    cookies.signed[:session_token] = {
       value: session_record.token,
       httponly: true,
       secure: Rails.env.production?,
-      same_site: :lax
+      same_site: :lax,
+      expires: SESSION_COOKIE_LIFETIME.from_now
     }
-    cookie_options[:expires] = 1.year.from_now
-
-    cookies.signed[:session_token] = cookie_options
   end
 
   def terminate_session

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,7 +1,7 @@
 module Authentication
   extend ActiveSupport::Concern
 
-  SESSION_COOKIE_LIFETIME = 20.years
+  SESSION_COOKIE_LIFETIME = 1.year
 
   included do
     before_action :resume_session

--- a/test/integration/auth_test.rb
+++ b/test/integration/auth_test.rb
@@ -17,7 +17,6 @@ class AuthTest < ActionDispatch::IntegrationTest
 
     get parent_children_path
 
-    assert_match(/expires=/i, session_token_cookie)
     assert session_token_cookie_expires > 10.years.from_now
   end
 
@@ -32,7 +31,6 @@ class AuthTest < ActionDispatch::IntegrationTest
 
     get child_dashboard_path
 
-    assert_match(/expires=/i, session_token_cookie)
     assert session_token_cookie_expires > 10.years.from_now
   end
 
@@ -116,7 +114,7 @@ class AuthTest < ActionDispatch::IntegrationTest
   end
 
   def session_token_cookie_expires
-    expires_str = session_token_cookie[/expires=([^;]+)/i, 1]
-    Time.parse(expires_str)
+    expires_str = session_token_cookie&.[](/expires=([^;]+)/i, 1)
+    Time.parse(expires_str) if expires_str
   end
 end

--- a/test/integration/auth_test.rb
+++ b/test/integration/auth_test.rb
@@ -6,10 +6,10 @@ class AuthTest < ActionDispatch::IntegrationTest
     assert_redirected_to parent_children_path
   end
 
-  test "parent login persists the session cookie with a far-future expiry" do
+  test "parent login persists the session cookie for one year" do
     post session_path, params: { email: users(:parent).email, password: "password" }
 
-    assert session_token_cookie_expires > 10.years.from_now
+    assert_session_cookie_expires_in_one_year
   end
 
   test "resuming a parent session renews the cookie expiration" do
@@ -17,13 +17,13 @@ class AuthTest < ActionDispatch::IntegrationTest
 
     get parent_children_path
 
-    assert session_token_cookie_expires > 10.years.from_now
+    assert_session_cookie_expires_in_one_year
   end
 
-  test "child login persists the session cookie with a far-future expiry" do
+  test "child login persists the session cookie for one year" do
     post session_path, params: { email: users(:user).email, password: "password" }
 
-    assert session_token_cookie_expires > 10.years.from_now
+    assert_session_cookie_expires_in_one_year
   end
 
   test "resuming a child session renews the cookie expiration" do
@@ -31,7 +31,7 @@ class AuthTest < ActionDispatch::IntegrationTest
 
     get child_dashboard_path
 
-    assert session_token_cookie_expires > 10.years.from_now
+    assert_session_cookie_expires_in_one_year
   end
 
   test "parent login fails with wrong password and redirects to login" do
@@ -116,5 +116,9 @@ class AuthTest < ActionDispatch::IntegrationTest
   def session_token_cookie_expires
     expires_str = session_token_cookie&.[](/expires=([^;]+)/i, 1)
     Time.parse(expires_str) if expires_str
+  end
+
+  def assert_session_cookie_expires_in_one_year
+    assert_in_delta 1.year.from_now.to_i, session_token_cookie_expires.to_i, 5.seconds
   end
 end

--- a/test/integration/auth_test.rb
+++ b/test/integration/auth_test.rb
@@ -6,10 +6,34 @@ class AuthTest < ActionDispatch::IntegrationTest
     assert_redirected_to parent_children_path
   end
 
-  test "parent login persists the session cookie" do
+  test "parent login persists the session cookie with a far-future expiry" do
     post session_path, params: { email: users(:parent).email, password: "password" }
 
+    assert session_token_cookie_expires > 10.years.from_now
+  end
+
+  test "resuming a parent session renews the cookie expiration" do
+    post session_path, params: { email: users(:parent).email, password: "password" }
+
+    get parent_children_path
+
     assert_match(/expires=/i, session_token_cookie)
+    assert session_token_cookie_expires > 10.years.from_now
+  end
+
+  test "child login persists the session cookie with a far-future expiry" do
+    post session_path, params: { email: users(:user).email, password: "password" }
+
+    assert session_token_cookie_expires > 10.years.from_now
+  end
+
+  test "resuming a child session renews the cookie expiration" do
+    post session_path, params: { email: users(:user).email, password: "password" }
+
+    get child_dashboard_path
+
+    assert_match(/expires=/i, session_token_cookie)
+    assert session_token_cookie_expires > 10.years.from_now
   end
 
   test "parent login fails with wrong password and redirects to login" do
@@ -86,6 +110,13 @@ class AuthTest < ActionDispatch::IntegrationTest
   end
 
   def session_token_cookie
-    response.headers["Set-Cookie"].split("\n").find { |cookie| cookie.start_with?("session_token=") }
+    set_cookie = response.headers["Set-Cookie"]
+    cookies = set_cookie.is_a?(Array) ? set_cookie : set_cookie.split("\n")
+    cookies.find { |cookie| cookie.start_with?("session_token=") }
+  end
+
+  def session_token_cookie_expires
+    expires_str = session_token_cookie[/expires=([^;]+)/i, 1]
+    Time.parse(expires_str)
   end
 end


### PR DESCRIPTION
Replaces the one-shot 1-year `session_token` cookie expiry with a `SESSION_COOKIE_LIFETIME = 20.years` constant and re-issues the cookie on every authenticated request via a new `renew_session_cookie` method, turning the fixed expiry into a sliding window. This fixes users being logged out frequently on mobile (especially Android WebAPK), where the OS kills browser processes and non-renewed cookies disappear. Adds integration tests asserting far-future expiry at login and on subsequent requests for both parent and child users, covering the pre-#113 asymmetric regression vector.